### PR TITLE
Feature/reflector

### DIFF
--- a/cluster/apps/kube-system/kustomization.yaml
+++ b/cluster/apps/kube-system/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - reflector

--- a/cluster/apps/kube-system/reflector/helm-release.yaml
+++ b/cluster/apps/kube-system/reflector/helm-release.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: reflector
+  namespace: kube-system
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: reflector
+      version: 6.1.23
+      sourceRef:
+        kind: HelmRepository
+        name: emberstack-charts
+        namespace: flux-system
+      interval: 5m
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    configuration:
+      logging:
+        minimumLevel: Debug

--- a/cluster/apps/kube-system/reflector/kustomization.yaml
+++ b/cluster/apps/kube-system/reflector/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml


### PR DESCRIPTION
**Description of the change**

Adds [reflector](https://github.com/emberstack/kubernetes-reflector) to the cluster.

**Benefits**

Mirror configmaps or secrets to other Kubernetes namespaces.

**Possible drawbacks**

Nothing in mind.

**Applicable issues**

None.

**Additional information**

Using helm chart for the installation.
