### PR TITLE
feat: deploys postgres database on the cluster

### DIFF
--- a/archive/kubernetes/metube/ks.yaml
+++ b/archive/kubernetes/metube/ks.yaml
@@ -1,5 +1,4 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/kustomization_v1beta2.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./postgres/ks.yaml
+  # - ./redis/ks.yaml

--- a/kubernetes/apps/database/namespace.yaml
+++ b/kubernetes/apps/database/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: database
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: postgresql
+  namespace: database
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: postgresql
+      version: 12.5.8
+      sourceRef:
+        kind: HelmRepository
+        name: chart-bitnami
+        namespace: flux-system
+  maxHistory: 3
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  dependsOn:
+    - name: longhorn
+      namespace: longhorn-system
+  values:
+    image:
+      repository: bitnami/postgresql
+      tag: 15.3.0
+    auth:
+      enablePostgresUser: true
+      postgresPassword: ${SECRET_POSTGRES_ADMIN_PASS}
+      database: postgres
+    primary:
+      persistence:
+        enabled: true
+        existingClaim: postgresql-data
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+      prometheusRule:
+        enabled: true

--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
       version: 12.5.8
       sourceRef:
         kind: HelmRepository
-        name: chart-bitnami
+        name: bitnami
         namespace: flux-system
   maxHistory: 3
   install:

--- a/kubernetes/apps/database/postgres/app/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/database/postgres/app/pvc.yaml
+++ b/kubernetes/apps/database/postgres/app/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgresql-data
+  namespace: database
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: longhorn

--- a/kubernetes/apps/database/postgres/ks.yaml
+++ b/kubernetes/apps/database/postgres/ks.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-database-postgres
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cluster-apps-longhorn
+  path: ./kubernetes/apps/database/postgres/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+      kind: HelmRelease
+      name: postgres
+      namespace: database
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m

--- a/kubernetes/flux/vars/cluster-secrets.sops.yaml
+++ b/kubernetes/flux/vars/cluster-secrets.sops.yaml
@@ -16,6 +16,7 @@ stringData:
     UP_UNIFI_SECRET: ENC[AES256_GCM,data:tWEMPh9px96NxFesug==,iv:6ObRncRUGDKYypwfHXn2oxTo+cB90/ZE0P+xwrUlYF4=,tag:tn9vRLLk2lCKO+DwSDAb4A==,type:str]
     SECRET_WIKIJS_DATABASE_PASSWORD: ENC[AES256_GCM,data:rK2xEPwY90Gs+RzKIS804FLFPW5B8HM=,iv:ohj1Xvb7h9ED1s2fX7PcKMAeP3hr+JlpdxjXraACLRs=,tag:fU4s3kTIJW/78dbfROhPOQ==,type:str]
     SECRET_DB_ROOT_PASSWORD: ENC[AES256_GCM,data:OFMqyFJ9QuPvZsRi1OQyUrL47IKUgw==,iv:2K3rcih7DxS5JebC2tGFS0550/jKzVYNmVUWNgr6sB0=,tag:H+d/sqcmQu9ryhVhRhYOdA==,type:str]
+    SECRET_POSTGRES_ADMIN_PASS: ENC[AES256_GCM,data:PpBLK9e/aaAft0WlmaGVYHIqtiImjyELA0I=,iv:IJ9G9Mhnft4F9NZfmuZ4jwgfFvqr3b/lZuqxJLq8W+I=,tag:KV3o23ZPLasZe1qEWus+AA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -31,8 +32,8 @@ sops:
             eEM3d1NoVHEvMFpmN1Q4aC9mYlpKMnMKeAYiW8THs2jnLtDFxOKYyc2XSG9lCz56
             PEw2Y9bMwqIADehlQoPMmBLs4UXNimAVjRPyIh4XOlrKCEZNuKmCRw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-05-18T10:45:52Z"
-    mac: ENC[AES256_GCM,data:pT7+j4WCSkmzEgwu/IEP0BPIkETyEX5+6zabUzKWo8pwhb9Nn6Tsp5nldvmvipbnjOXicuNX2GDDh8KgN3Vmhu2iyMIua9B98s/mFuP9NIIpTChLVegiViFTFU7LGIg1ESdOIixi+gvNW36vwaRH4pIM9QJbrwdrnvKg107n+O8=,iv:1RzJIPepOnRzlrI2WFPyj6HYSOnxFv/C65PKGmJdhC0=,tag:H/37WqY6N2cIgfDpsGTMkA==,type:str]
+    lastmodified: "2023-06-25T16:15:31Z"
+    mac: ENC[AES256_GCM,data:wKxeuj1Die3Xx95L75T37y0pUCJizIG0CXPL1oZV1KeoMVUF3u9kUjCU+iZwkrALrH/KoZUhGW+t1UggvYI0DWDkoy65RyRABpH3rt1q38MgAJXeGdBGG1mecsz8x2mI2P+gy/3xlaukGLsFtxUIyTZ9HdouZeUZO+O67nhtWmQ=,iv:LNtlEhWai3cl1MojPHaGLfxrLcJzjkT0k6ybYN5F1pM=,tag:t1xalh24dyzsLJGoqoQt+Q==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.3


### PR DESCRIPTION
**Description of the change**

Creates new namespace - database for postgres, mariadb, redis... storage apps.

**Benefits**

Postgres using strong power of k8s unlink lxc container which would have 1 thread.

**Possible drawbacks**

The old question: _"Should be database deployed as container on k8s"_?


