### PR TITLE
adds uptime gatus tool

### DIFF
--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       version: 1.5.1
       sourceRef:
         kind: HelmRepository
-        name: bjw-s
+        name: bjw-s-charts
         namespace: flux-system
   maxHistory: 2
   install:

--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -35,16 +35,17 @@ spec:
             image:
               repository: ghcr.io/onedr0p/postgres-init
               tag: 16
+              pullPolicy: IfNotPresent
             envFrom: &envFrom
               - secretRef:
                   name: gatus-secret
-          # TODO: Convert this to a proper 'sidecar' container someday
           init-config:
             order: 2
             image: &configSyncImage
               repository: ghcr.io/kiwigrid/k8s-sidecar
-              tag: 1.25.3@sha256:8dc0aca015bf7173378ee5987dd78d49f94ff9a5c3495b3664141750cc55f444
-            env: &configSyncEnv
+              tag: 1.25.3
+              pullPolicy: IfNotPresent
+            env:
               FOLDER: /config
               LABEL: gatus.io/enabled
               NAMESPACE: ALL
@@ -63,7 +64,7 @@ spec:
               repository: ghcr.io/twin/gatus
               tag: v5.7.0@sha256:e077910eeda4c1369e20c74bd09853b141399103531d97d831d1ae58bd81537d
             env:
-              TZ: America/New_York
+              TZ: ${TIMEZONE}
               GATUS_CONFIG_PATH: /config
               CUSTOM_WEB_PORT: &port 80
             envFrom: *envFrom
@@ -80,9 +81,12 @@ spec:
           config-sync:
             image: *configSyncImage
             env:
-              <<: *configSyncEnv
+              FOLDER: /config
+              LABEL: gatus.io/enabled
+              NAMESPACE: ALL
+              RESOURCE: both
+              UNIQUE_FILENAMES: true
               METHOD: WATCH
-            securityContext: *securityContext
             resources: *configSyncResources
         pod:
           securityContext:

--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -1,0 +1,138 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/helm.toolkit.fluxcd.io/helmrelease_v2beta1.json
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: gatus
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 2.3.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init-db:
+            order: 1
+            image:
+              repository: ghcr.io/onedr0p/postgres-init
+              tag: 16
+            envFrom: &envFrom
+              - secretRef:
+                  name: gatus-secret
+          # TODO: Convert this to a proper 'sidecar' container someday
+          init-config:
+            order: 2
+            image: &configSyncImage
+              repository: ghcr.io/kiwigrid/k8s-sidecar
+              tag: 1.25.3@sha256:8dc0aca015bf7173378ee5987dd78d49f94ff9a5c3495b3664141750cc55f444
+            env: &configSyncEnv
+              FOLDER: /config
+              LABEL: gatus.io/enabled
+              NAMESPACE: ALL
+              RESOURCE: both
+              UNIQUE_FILENAMES: true
+              METHOD: LIST
+            resources: &configSyncResources
+              requests:
+                cpu: 10m
+                memory: 10Mi
+              limits:
+                memory: 128Mi
+        containers:
+          main:
+            image:
+              repository: ghcr.io/twin/gatus
+              tag: v5.7.0@sha256:e077910eeda4c1369e20c74bd09853b141399103531d97d831d1ae58bd81537d
+            env:
+              TZ: America/New_York
+              GATUS_CONFIG_PATH: /config
+              CUSTOM_WEB_PORT: &port 80
+            envFrom: *envFrom
+            securityContext: &securityContext
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256M
+              limits:
+                memory: 512M
+          config-sync:
+            image: *configSyncImage
+            env:
+              <<: *configSyncEnv
+              METHOD: WATCH
+            securityContext: *securityContext
+            resources: *configSyncResources
+        pod:
+          securityContext:
+            runAsUser: 568
+            runAsGroup: 568
+            runAsNonRoot: true
+            fsGroup: 568
+            fsGroupChangePolicy: OnRootMismatch
+    service:
+      main:
+        ports:
+          http:
+            port: *port
+    serviceMonitor:
+      main:
+        enabled: true
+    ingress:
+      main:
+        enabled: true
+        className: external
+        annotations:
+          external-dns.alpha.kubernetes.io/target: external.devbu.io
+        hosts:
+          - host: &host "{{ .Release.Name }}.devbu.io"
+            paths:
+              - path: /
+                service:
+                  name: main
+                  port: http
+          - host: &customHost status.devbu.io
+            paths:
+              - path: /
+                service:
+                  name: main
+                  port: http
+        tls:
+          - hosts:
+              - *host
+              - *customHost
+    serviceAccount:
+      create: true
+      name: gatus
+    persistence:
+      config:
+        enabled: true
+        type: emptyDir
+      config-file:
+        type: configMap
+        name: gatus-configmap
+        globalMounts:
+          - path: /config/config.yaml
+            subPath: config.yaml
+            readOnly: true

--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -4,18 +4,20 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: gatus
+  namespace: monitoring
 spec:
   interval: 30m
   chart:
     spec:
       chart: app-template
-      version: 2.3.0
+      version: 1.5.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
   maxHistory: 2
   install:
+    createNamespace: true
     remediation:
       retries: 3
   upgrade:
@@ -25,118 +27,79 @@ spec:
   uninstall:
     keepHistory: false
   values:
-    controllers:
-      main:
-        annotations:
-          reloader.stakater.com/auto: "true"
-        initContainers:
-          init-db:
-            order: 1
-            image:
-              repository: ghcr.io/onedr0p/postgres-init
-              tag: 16
-              pullPolicy: IfNotPresent
-            envFrom: &envFrom
-              - secretRef:
-                  name: gatus-secret
-          init-config:
-            order: 2
-            image: &configSyncImage
-              repository: ghcr.io/kiwigrid/k8s-sidecar
-              tag: 1.25.3
-              pullPolicy: IfNotPresent
-            env:
-              FOLDER: /config
-              LABEL: gatus.io/enabled
-              NAMESPACE: ALL
-              RESOURCE: both
-              UNIQUE_FILENAMES: true
-              METHOD: LIST
-            resources: &configSyncResources
-              requests:
-                cpu: 10m
-                memory: 10Mi
-              limits:
-                memory: 128Mi
-        containers:
-          main:
-            image:
-              repository: ghcr.io/twin/gatus
-              tag: v5.7.0@sha256:e077910eeda4c1369e20c74bd09853b141399103531d97d831d1ae58bd81537d
-            env:
-              TZ: ${TIMEZONE}
-              GATUS_CONFIG_PATH: /config
-              CUSTOM_WEB_PORT: &port 80
-            envFrom: *envFrom
-            securityContext: &securityContext
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
-            resources:
-              requests:
-                cpu: 10m
-                memory: 256M
-              limits:
-                memory: 512M
-          config-sync:
-            image: *configSyncImage
-            env:
-              FOLDER: /config
-              LABEL: gatus.io/enabled
-              NAMESPACE: ALL
-              RESOURCE: both
-              UNIQUE_FILENAMES: true
-              METHOD: WATCH
-            resources: *configSyncResources
-        pod:
-          securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            runAsNonRoot: true
-            fsGroup: 1000
-            fsGroupChangePolicy: OnRootMismatch
+    initContainers:
+      01-init-db:
+        image: ghcr.io/onedr0p/postgres-init:14.8
+        imagePullPolicy: IfNotPresent
+        envFrom: &envFrom
+          - secretRef:
+              name: gatus-secret
+    controller:
+      annotations:
+        reloader.stakater.com/auto: "true"
+    image:
+      repository: ghcr.io/twin/gatus
+      tag: v5.4.0
+    env:
+      TZ: ${TIMEZONE}
+      GATUS_CONFIG_PATH: /config
+      CUSTOM_WEB_PORT: &port 80
+    envFrom: *envFrom
     service:
       main:
         ports:
           http:
             port: *port
-    serviceMonitor:
-      main:
-        enabled: true
     ingress:
       main:
         enabled: true
-        className: external
-        annotations:
-          external-dns.alpha.kubernetes.io/target: external.devbu.io
+        ingressClassName: nginx
+        # TODO: add external-dns annotation
+        # annotations:
+        #   external-dns.alpha.kubernetes.io/target: ingress.devbu.io
         hosts:
-          - host: &host "{{ .Release.Name }}.devbu.io"
+          - host: &host status.${SECRET_DOMAIN}
             paths:
               - path: /
-                service:
-                  name: main
-                  port: http
-          - host: &customHost status.devbu.io
-            paths:
-              - path: /
-                service:
-                  name: main
-                  port: http
+                pathType: Prefix
         tls:
           - hosts:
               - *host
-              - *customHost
     serviceAccount:
       create: true
       name: gatus
+    podSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     persistence:
       config:
         enabled: true
         type: emptyDir
       config-file:
+        enabled: true
         type: configMap
         name: gatus-configmap
-        globalMounts:
-          - path: /config/config.yaml
-            subPath: config.yaml
-            readOnly: true
+        mountPath: /config/config.yaml
+        subPath: config.yaml
+        readOnly: true
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        memory: 500Mi
+    sidecars:
+      config-sync:
+        image: ghcr.io/kiwigrid/k8s-sidecar:1.24.4
+        imagePullPolicy: IfNotPresent
+        env:
+          - { name: FOLDER, value: /config }
+          - { name: LABEL, value: gatus.io/enabled }
+          - { name: NAMESPACE, value: ALL }
+          - { name: RESOURCE, value: both }
+          - { name: UNIQUE_FILENAMES, value: "true" }
+          - { name: METHOD, value: WATCH }
+        volumeMounts:
+          - { name: config, mountPath: /config }

--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -90,10 +90,10 @@ spec:
             resources: *configSyncResources
         pod:
           securityContext:
-            runAsUser: 568
-            runAsGroup: 568
+            runAsUser: 1000
+            runAsGroup: 1000
             runAsNonRoot: true
-            fsGroup: 568
+            fsGroup: 1000
             fsGroupChangePolicy: OnRootMismatch
     service:
       main:

--- a/kubernetes/apps/monitoring/gatus/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./secret.sops.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: gatus-configmap
+    files:
+      - config.yaml=./resources/config.yaml
+# generatorOptions:
+#   disableNameSuffixHash: true
+#   annotations:
+#     kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/monitoring/gatus/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/kustomization.yaml
@@ -8,7 +8,7 @@ configMapGenerator:
   - name: gatus-configmap
     files:
       - config.yaml=./resources/config.yaml
-# generatorOptions:
-#   disableNameSuffixHash: true
-#   annotations:
-#     kustomize.toolkit.fluxcd.io/substitute: disabled
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/monitoring/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/resources/config.yaml
@@ -1,0 +1,46 @@
+---
+web:
+  port: ${CUSTOM_WEB_PORT}
+storage:
+  type: postgres
+  path: postgres://${INIT_POSTGRES_USER}:${INIT_POSTGRES_PASS}@${INIT_POSTGRES_HOST}:5432/${INIT_POSTGRES_DBNAME}?sslmode=disable
+  caching: true
+metrics: true
+debug: false
+ui:
+  title: Status | Gatus
+  header: Status
+alerting:
+  pushover:
+    application-token: ${CUSTOM_PUSHOVER_TOKEN}
+    user-key: ${CUSTOM_PUSHOVER_USER_KEY}
+    default-alert:
+      description: health-check failed
+      send-on-resolved: true
+      failure-threshold: 5
+      success-threshold: 2
+connectivity:
+  checker:
+    target: 1.1.1.1:53
+    interval: 1m
+endpoints:
+  - name: status
+    group: external
+    url: https://status.devbu.io
+    interval: 1m
+    client:
+      dns-resolver: tcp://1.1.1.1:53
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: pushover
+  - name: flux-webhook
+    group: external
+    url: https://flux-webhook.devbu.io
+    interval: 1m
+    client:
+      dns-resolver: tcp://1.1.1.1:53
+    conditions:
+      - "[STATUS] == 404"
+    alerts:
+      - type: pushover

--- a/kubernetes/apps/monitoring/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/resources/config.yaml
@@ -11,36 +11,31 @@ ui:
   title: Status | Gatus
   header: Status
 alerting:
-  pushover:
-    application-token: ${CUSTOM_PUSHOVER_TOKEN}
-    user-key: ${CUSTOM_PUSHOVER_USER_KEY}
-    default-alert:
-      description: health-check failed
-      send-on-resolved: true
-      failure-threshold: 5
-      success-threshold: 2
+  discord:
+    webhook-url: ${SECRET_GATUS_DISCORD_WEBHOOK}
 connectivity:
   checker:
     target: 1.1.1.1:53
     interval: 1m
-endpoints:
-  - name: status
-    group: external
-    url: https://status.devbu.io
-    interval: 1m
-    client:
-      dns-resolver: tcp://1.1.1.1:53
-    conditions:
-      - "[STATUS] == 200"
-    alerts:
-      - type: pushover
-  - name: flux-webhook
-    group: external
-    url: https://flux-webhook.devbu.io
-    interval: 1m
-    client:
-      dns-resolver: tcp://1.1.1.1:53
-    conditions:
-      - "[STATUS] == 404"
-    alerts:
-      - type: pushover
+# TODO: add these when they are ready
+# endpoints:
+  # - name: status
+  #   group: external
+  #   url: https://status
+  #   interval: 1m
+  #   client:
+  #     dns-resolver: tcp://1.1.1.1:53
+  #   conditions:
+  #     - "[STATUS] == 200"
+  #   alerts:
+  #     - type: pushover
+  # - name: flux-webhook
+  #   group: external
+  #   url: https://flux-webhook
+  #   interval: 1m
+  #   client:
+  #     dns-resolver: tcp://1.1.1.1:53
+  #   conditions:
+  #     - "[STATUS] == 404"
+  #   alerts:
+  #     - type: pushover

--- a/kubernetes/apps/monitoring/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/resources/config.yaml
@@ -17,18 +17,12 @@ connectivity:
   checker:
     target: 1.1.1.1:53
     interval: 1m
-# TODO: add these when they are ready
-# endpoints:
-  # - name: status
-  #   group: external
-  #   url: https://status
-  #   interval: 1m
-  #   client:
-  #     dns-resolver: tcp://1.1.1.1:53
-  #   conditions:
-  #     - "[STATUS] == 200"
-  #   alerts:
-  #     - type: pushover
+endpoints:
+  - name: status
+    url: https://status.${SECRET_DOMAIN}
+    interval: 1m
+    conditions: ["[STATUS] == 200"]
+    alerts: [{ type: pushover }]
   # - name: flux-webhook
   #   group: external
   #   url: https://flux-webhook

--- a/kubernetes/apps/monitoring/gatus/app/secret.sops.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/secret.sops.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./secret.sops.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: gatus-configmap
+    files:
+      - config.yaml=./resources/config.yaml
+# generatorOptions:
+#   disableNameSuffixHash: true
+#   annotations:
+#     kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/monitoring/gatus/app/secret.sops.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/secret.sops.yaml
@@ -1,14 +1,33 @@
----
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - ./secret.sops.yaml
-  - ./helmrelease.yaml
-configMapGenerator:
-  - name: gatus-configmap
-    files:
-      - config.yaml=./resources/config.yaml
-# generatorOptions:
-#   disableNameSuffixHash: true
-#   annotations:
-#     kustomize.toolkit.fluxcd.io/substitute: disabled
+# yamllint disable
+apiVersion: v1
+kind: Secret
+metadata:
+    name: gatus-secret
+    namespace: monitoring
+stringData:
+    DISCORD_WEBHOOK_URL: ENC[AES256_GCM,data:dx+RrgWPNJyBQb58sKQ2d4pMUK3hwXtVt14=,iv:dt9SsY2uF77CpPIcSBrkNNIGR/xM5Z85zEpIfySrJUU=,tag:CfLOpnURa3ngy0J+LcpWuQ==,type:str]
+    INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:ime9Ac0=,iv:HCUR8F1E8knuEEBgjuADBXbAEUXdUmpSCJE4C+WmlPI=,tag:bsDWkfewgrW6hx7ifqyBWQ==,type:str]
+    INIT_POSTGRES_HOST: ENC[AES256_GCM,data:Ae4SxEpPYP1xkpbjFfyuxZFjORTcbd92j7wxNJUJeqreQ54nZA==,iv:YgDQOoUItfF0+5FLqjimBAQStUZBiOUhPQirapzcQT0=,tag:EV/s/JQhohnFzYdxlqByZQ==,type:str]
+    INIT_POSTGRES_USER: ENC[AES256_GCM,data:Naxp1Mk=,iv:JNGCBebxXmp9PW+0MHCN3vRRME1zygzkvAtjI0L9GtM=,tag:MYUVUg4OOGhFaWlRwwhtCA==,type:str]
+    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:b1ylAAwExAZwD6PU,iv:vkZPPq1n80Yj3Jc6lsBJAeYp9QGJZq5zhZzYWGWVxdk=,tag:bZdd/PSLb6RZ2eP9kL2reA==,type:str]
+    INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:Aaby,iv:OUuK6tJ/SVNKRAjp2m3JJKX0VVOf6hZ3Q3kjh2FWE1I=,tag:EWpqkq+BNhhJWOQycf9l9w==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age12evtyez2gz3w209lld8r6nw0v0572v468v0hl05m5259v0zrn5eq3cct4h
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4eElTNWwvTmsvaTN1THpp
+            QlVVQ1dwajkyUDI2L0NsSnc1OFkxc2ZyMUJzCk5ZZFNYQ3BsciswVlBGQ0tLT2ly
+            SnBqTDRVaysxQ3RZSnhCNFpVRmYxYnMKLS0tIHdGVmljT2RGSUpoMk5HMXVtNWcr
+            ZE5sUXJsNUIrbEpVcy9CTitxZHg1ckEK/On0z5lWrM0b2/y4izv29kGKxXMJmYmT
+            SX77G8lIfK6ts+MceraYmjdUINxWMswh5E/HIMe1f6A5CL4jumpgPA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2023-12-13T23:34:50Z"
+    mac: ENC[AES256_GCM,data:vzSfr/6F8MNxeHzLa2qwejP5DbUxwHA9r9kudnPRiSK/VgVvee3nCn0bTrNqTjG5tqVkx2UniVQ0tTIfP3hayqCxW+SRWEREm0xQrrP71/YUYkqCa63EmurrSa+m7EALavMOEKlGa2hMrDOc59xEyYeyaut5u9IiwfBLlxDPbbc=,iv:xK48vYBHUcdLrpwS7w2P5FE+WBaQ5Nkt8WAPf+NYBVg=,tag:9/QirTMJ4Y6rNze/Um+qew==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.3

--- a/kubernetes/apps/monitoring/gatus/app/secret.sops.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/secret.sops.yaml
@@ -5,7 +5,7 @@ metadata:
     name: gatus-secret
     namespace: monitoring
 stringData:
-    DISCORD_WEBHOOK_URL: ENC[AES256_GCM,data:dx+RrgWPNJyBQb58sKQ2d4pMUK3hwXtVt14=,iv:dt9SsY2uF77CpPIcSBrkNNIGR/xM5Z85zEpIfySrJUU=,tag:CfLOpnURa3ngy0J+LcpWuQ==,type:str]
+    DISCORD_WEBHOOK_URL: ENC[AES256_GCM,data:SW/QlLm/aMpdf6vuZ6qGJZVRa5w4pa/EAMc/j9nleLsdyy+TWpUPnBYM3jK/TUnDzE+xwFeIaQi2zWzqkt0c0Y5cU6yQi3q5WhAq+NZjd7S+5XkfFkF5qwWgHRQXfr9uoZ61FFqq9jhicbFmnY6A3L1UTDVH0z+X,iv:LOlbmLCFemq3RGXi1VMKIWVpDJOUXo4fBOFdHRgos8I=,tag:WP/Ui2XURqWy7YNILqd+gg==,type:str]
     INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:ime9Ac0=,iv:HCUR8F1E8knuEEBgjuADBXbAEUXdUmpSCJE4C+WmlPI=,tag:bsDWkfewgrW6hx7ifqyBWQ==,type:str]
     INIT_POSTGRES_HOST: ENC[AES256_GCM,data:Ae4SxEpPYP1xkpbjFfyuxZFjORTcbd92j7wxNJUJeqreQ54nZA==,iv:YgDQOoUItfF0+5FLqjimBAQStUZBiOUhPQirapzcQT0=,tag:EV/s/JQhohnFzYdxlqByZQ==,type:str]
     INIT_POSTGRES_USER: ENC[AES256_GCM,data:Naxp1Mk=,iv:JNGCBebxXmp9PW+0MHCN3vRRME1zygzkvAtjI0L9GtM=,tag:MYUVUg4OOGhFaWlRwwhtCA==,type:str]
@@ -26,8 +26,8 @@ sops:
             ZE5sUXJsNUIrbEpVcy9CTitxZHg1ckEK/On0z5lWrM0b2/y4izv29kGKxXMJmYmT
             SX77G8lIfK6ts+MceraYmjdUINxWMswh5E/HIMe1f6A5CL4jumpgPA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-12-13T23:34:50Z"
-    mac: ENC[AES256_GCM,data:vzSfr/6F8MNxeHzLa2qwejP5DbUxwHA9r9kudnPRiSK/VgVvee3nCn0bTrNqTjG5tqVkx2UniVQ0tTIfP3hayqCxW+SRWEREm0xQrrP71/YUYkqCa63EmurrSa+m7EALavMOEKlGa2hMrDOc59xEyYeyaut5u9IiwfBLlxDPbbc=,iv:xK48vYBHUcdLrpwS7w2P5FE+WBaQ5Nkt8WAPf+NYBVg=,tag:9/QirTMJ4Y6rNze/Um+qew==,type:str]
+    lastmodified: "2023-12-13T23:50:41Z"
+    mac: ENC[AES256_GCM,data:gNUCPkHuwyLQ6ZHiFfdrhWRa6fTbsOaJ6jLacBKhgEL3xAk+E7hca0UpCBO15SIyNpAf7kjSBz/h4uom5z2UbRGLb/h5e6DILEyb2z/GzvS1pddnkiVqvtberm+ZY2s6FuXCQYlezyYng5YWS4tcQxwYH6kIrZPF+7KK8It4ROw=,iv:gwdoX8CfpfjJp8zP5eF+vgOzaXh4zfF0D/EDP+s1jvM=,tag:PYxChI7MEpwMp7hken5v5A==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.3

--- a/kubernetes/apps/monitoring/gatus/ks.yaml
+++ b/kubernetes/apps/monitoring/gatus/ks.yaml
@@ -3,21 +3,22 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: cluster-apps-external-metube
+  name: &app gatus
   namespace: flux-system
 spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
   dependsOn:
-    - name: cluster-apps-traefik
-  path: ./kubernetes/apps/external/metube/app
+    - name: cloudnative-pg-cluster
+    - name: external-secrets-stores
+  path: ./kubernetes/main/apps/monitoring/gatus/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: home-kubernetes
-  healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
-      kind: HelmRelease
-      name: metube
-      namespace: external
+  wait: false
   interval: 30m
   retryInterval: 1m
-  timeout: 3m
+  timeout: 5m

--- a/kubernetes/apps/monitoring/grafana/app/gatus.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/gatus.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-gatus-ep
+  namespace: monitoring
+  labels:
+    gatus.io/enabled: "true"
+data:
+  config.yaml: |
+    endpoints:
+      - name: grafana
+        url: https://grafana.${SECRET_DOMAIN}
+        interval: 1m
+        conditions: ["[STATUS] == 200"]
+        alerts: [{ type: pushover }]

--- a/kubernetes/apps/monitoring/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./secret.sops.yaml
+  - ./gatus.yaml


### PR DESCRIPTION
**Description of the change**

Brings gatus to k8s cluster. For cluster apps to monitoring. 

**Benefits**

Scailable monitoring

**Possible drawbacks**

Running status machine on k8s if k8s starts failing I can loose monitoring as well.

**Applicable issues**

- fixes https://github.com/axeII/home-ops/issues/593

**Additional information**

Currently this will migrate to gatus which will be oppened to world via cloudflare tunnel. And in next phase I will add monitoring to the healcheck.
