### PR TITLE
fix(helmrelease): update host configurations for komga

### DIFF
--- a/kubernetes/apps/media/komga/app/helmrelease.yaml
+++ b/kubernetes/apps/media/komga/app/helmrelease.yaml
@@ -56,14 +56,18 @@ spec:
           gatus.io/enabled: "true"
           hajimari.io/icon: "mdi:thought-bubble-outline"
         hosts:
-          - host: &host "{{ .Release.Name }}.${SECRET_DOMAIN}"
-            paths:
+          - host: &host "{{ .Release.Name }}.juno.moe"
+            paths: &paths
               - path: /
                 service:
                   identifier: app
                   port: http
+          - host: &chost "comics.juno.moe"
+            paths: *paths
         tls:
-          - hosts: [*host]
+          - hosts:
+              - *host
+              - *chost
     persistence:
       config:
         existingClaim: *app


### PR DESCRIPTION
Update the host entries in the helmrelease.yaml file for the 
komga application. Change the primary host to use 
"{{ .Release.Name }}.juno.moe" and add a new host 
"comics.juno.moe" with shared paths. This improves 
domain management and ensures proper routing for the 
application's services.