### PR TITLE
chore: update container images for media applications

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -27,8 +27,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/onedr0p/plex-beta
-              tag: 1.41.3.9314-a0bfb8370@sha256:679db51b7226f8d04c4812d4885a02a51607727b0a5e1523c5a00c570112753e
+              repository: ghcr.io/home-operations/plex
+              tag: 1.41.5.9522@sha256:cb0310eb53e8ff6e51be2869b6de0425f649e631aa329e6ccf0c72ba580a8aa3
             env:
               # PLEX_ADVERTISE_URL: https://{{ .Release.Name }}.${SECRET_DOMAIN}:443
               ADVERTISE_IP: "https://plex.${SECRET_DOMAIN},http://${PLEX_IP}:32400"

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -37,8 +37,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/buroa/prowlarr-develop
-              tag: 1.30.2.4939@sha256:fb15782d6c1fa7aec6ed82baeca08c73cab2fd48bb9167d699787cb260883cf3
+              repository: ghcr.io/home-operations/prowlarr
+              tag: 1.33.0.4994@sha256:b1b4da4df605bec0ba810cf18abf91bc6569f5d8144a64da699cb78a7c2ec30c
             env:
               PROWLARR__APP__INSTANCENAME: Prowlarr
               PROWLARR__APP__THEME: dark

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -37,8 +37,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/buroa/radarr-develop
-              tag: 5.19.0.9697@sha256:b920f18694e6129d26fae37612d0a770a413bf9923080d6a7858da2cb8d2a6da
+              repository: ghcr.io/home-operations/radarr
+              tag: 5.21.1.9799@sha256:13171f1d476b4b0c9a44191ae60ddd0d1581b9cd89f9c5f7a82be602c0f95096
             env:
               RADARR__APP__INSTANCENAME: Radarr
               RADARR__APP__THEME: dark

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -29,8 +29,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/buroa/sabnzbd
-              tag: 4.4.1@sha256:146646057a9049b4eca4b9996b3e2d3135a520402cf64f00abba0ef17f00d1d1
+              repository: ghcr.io/home-operations/sabnzbd
+              tag: 4.4.1@sha256:bb77343461b9254a26465a3c788aafecfe44fc74bae6eecba6adf66010e13bfc
             env:
               SABNZBD__PORT: &port 8080
               SABNZBD__HOST_WHITELIST_ENTRIES: >-

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -37,8 +37,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/buroa/sonarr-develop
-              tag: 4.0.13.2931@sha256:d0d8d453c525bddcdbedf9d83c0e814430534a8203a28a1cb33fbe386996cff2
+              repository: ghcr.io/home-operations/sonarr
+              tag: 4.0.14.2938@sha256:acd5416ab9c36d017687820a32f09d09a4e25a5754aa5ebeae2e7c63d7609c13
             env:
               SONARR__APP__INSTANCENAME: Sonarr
               SONARR__APP__THEME: dark


### PR DESCRIPTION
Update the image repositories and tags for Sonarr, Prowlarr, Plex, 
Radarr, and Sabnzbd to use the new home-operations images. This 
ensures that the applications are using the latest versions and 
maintains consistency across the deployments.