### PR TITLE
feat: adds new oci repository for app template

### DIFF
--- a/kubernetes/flux/repositories/oci/app-template.yaml
+++ b/kubernetes/flux/repositories/oci/app-template.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: app-template
+  namespace: flux-system
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 3.7.3
+  url: oci://ghcr.io/bjw-s/helm/app-template
+  verify:
+    provider: cosign

--- a/kubernetes/flux/repositories/oci/kustomization.yaml
+++ b/kubernetes/flux/repositories/oci/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./app-template.yaml
   - ./kyverno.yaml


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Adds OCI for app template as option to migrate from helm to OCI.

**Benefits or applicable issues**
Easier to handle the app template updates

<!-- What benefits will be realized by the code change and any applicable issues here? -->
- fixes https://github.com/axeII/home-ops/issues/1650
