### PR TITLE
fix: update HelmRelease interval from 30m to 1h

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: cert-manager
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: cert-manager

--- a/kubernetes/apps/default/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/atuin/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: HelmRelease
 metadata:
   name: &app atuin
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: cilium
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: cilium

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: coredns
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: coredns

--- a/kubernetes/apps/kube-system/external-secrets/stores/onepassword/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/onepassword/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app onepassword-connect
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/kube-system/kubelet-csr-approver/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/kubelet-csr-approver/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: kubelet-csr-approver
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: kubelet-csr-approver

--- a/kubernetes/apps/kube-system/local-path-provisioner/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/local-path-provisioner/app/helmrelease.yaml
@@ -4,7 +4,7 @@ metadata:
   name: local-path-provisioner
   namespace: kube-system
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: democratic-csi

--- a/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: metrics-server
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: metrics-server

--- a/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reloader/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: reloader
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: reloader

--- a/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: spegel
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: spegel

--- a/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app kyverno
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: kyverno

--- a/kubernetes/apps/media/komga/app/helmrelease.yaml
+++ b/kubernetes/apps/media/komga/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: HelmRelease
 metadata:
   name: &app komga
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app plex
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app prowlarr
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app radarr
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: HelmRelease
 metadata:
   name: recyclarr
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app sabnzbd
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app sonarr
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app unpackerr
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: cloudflared
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/network/e1000e-fix/app/helmrelease.yaml
+++ b/kubernetes/apps/network/e1000e-fix/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: HelmRelease
 metadata:
   name: &app e1000e-fix
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/network/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo-server/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: echo-server
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/network/external-dns/cloudflare/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/cloudflare/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app external-dns
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: external-dns

--- a/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app external-dns-unifi
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: external-dns

--- a/kubernetes/apps/network/ingress-nginx/external/helmrelease.yaml
+++ b/kubernetes/apps/network/ingress-nginx/external/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: ingress-nginx-external
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: ingress-nginx

--- a/kubernetes/apps/network/ingress-nginx/internal/helmrelease.yaml
+++ b/kubernetes/apps/network/ingress-nginx/internal/helmrelease.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ingress-nginx-internal
   namespace: network
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: ingress-nginx

--- a/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: k8s-gateway
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: k8s-gateway

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app gatus
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app grafana
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: grafana

--- a/kubernetes/apps/observability/karma/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/karma/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app karma
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app kromgo
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: HelmRelease
 metadata:
   name: kube-prometheus-stack
 spec:
-  interval: 30m
+  interval: 1h
   timeout: 15m
   chart:
     spec:

--- a/kubernetes/apps/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/loki/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: loki
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: loki

--- a/kubernetes/apps/observability/prometheus-operator-crds/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/prometheus-operator-crds/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: prometheus-operator-crds
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: prometheus-operator-crds

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: rook-ceph-operator
 spec:
-  interval: 30m
+  interval: 1h
   timeout: 15m
   chart:
     spec:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -6,7 +6,7 @@ metadata:
   name: rook-ceph-cluster
   namespace: rook-ceph
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: rook-ceph-cluster

--- a/kubernetes/apps/volsync-system/snapshot-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/snapshot-controller/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: snapshot-controller
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: snapshot-controller

--- a/kubernetes/apps/volsync-system/volsync/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: HelmRelease
 metadata:
   name: volsync
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: volsync


### PR DESCRIPTION
**Description of the change**

This pull request updates the interval for multiple HelmRelease configurations from 30 minutes to 1 hour. This change is intended to reduce the frequency of updates, thereby optimizing resource usage and improving overall system performance.

**Benefits or applicable issues**

By increasing the update interval, we can reduce the load on the system and enhance stability. This change will help in managing resources more efficiently and may lead to better performance in environments with high resource consumption.
- fixes #