### PR TITLE
fix(kustomization): update namespace for tautulli app

### DIFF
--- a/kubernetes/apps/media/tautulli/ks.yaml
+++ b/kubernetes/apps/media/tautulli/ks.yaml
@@ -3,7 +3,8 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app tautulli
-  namespace: &namespace media
+  namespace: flux-system
+  # namespace: &namespace media
 spec:
   commonMetadata:
     labels:


### PR DESCRIPTION
Change the namespace for the tautulli application from 'media' to 
'flux-system' to align with the new deployment strategy. This 
ensures