### PR TITLE
fix: standardize YAML syntax and update secret name

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -20,8 +20,7 @@ jobs:
         id: changed-files
         uses: bjw-s-labs/action-changed-files@b1144fc772fca235a50902c7bb6cc431cc7d8e27 # v0.3.2
         with:
-          patterns: |-
-            kubernetes/**/*
+          patterns: kubernetes/**/*
 
   test:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
@@ -108,7 +107,7 @@ jobs:
 
   success:
     if: ${{ !cancelled() }}
-    needs: [test, diff]
+    needs: ["test", "diff"]
     name: Flux Local - Success
     runs-on: ubuntu-latest
     steps:

--- a/kubernetes/components/volsync/r2/externalsecret.yaml
+++ b/kubernetes/components/volsync/r2/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword
+    name: onepassword-connect
   target:
     name: "${APP}-restic-secret"
     template:


### PR DESCRIPTION
Update the `needs` syntax in the Flux Local workflow for consistency.  
Change the secret name in the ExternalSecret configuration to reflect  
the correct reference. Simplify the patterns definition in the  
changed-files action for clarity. These changes enhance readability  
and maintainability of the configuration files.