### PR TITLE
✨ feat(minecraft): Add WorldEdit, LuckPerms and Distant Horizons

### DIFF
--- a/kubernetes/apps/default/minecraft/app/helmrelease.yaml
+++ b/kubernetes/apps/default/minecraft/app/helmrelease.yaml
@@ -47,10 +47,10 @@ spec:
     minecraftServer:
       eula: true
       version: 1.21.8
-      type: PAPER
+      type: FABRIC
       difficulty: normal
       whitelist: "Speeddrat,Anty0,phonyAustralian,TheHnatekmar,DemTriangles,MountHelen1980" # Pridat bioaldu
-      ops: "phonyAustralian"
+      ops: "phonyAustralian,DemTriangles"
       pvp: true
       motd: Meh
       worldSaveName: "The Forgotten Realm"
@@ -75,6 +75,11 @@ spec:
             embedded: false
             type: ClusterIP
             port: 8100
+      modrinth:
+        projects:
+          - worldedit
+          - luckperms
+          - distanthorizons
   valuesFrom:
     - kind: Secret
       name: *secret


### PR DESCRIPTION
WorldEdit is a Minecraft map editor... that runs in-game! With selections, schematics, copy and paste, brushes, and scripting.

LuckPerms is a permission plugin so that you can actually allow me to use WorldEdit.

Distant Horizons can be used entirely client side, but the server side component additionally allows the server to generate LODs, which is cool.

Distant Horizons requires Fabric, so I've switched the server from Paper to Fabric. Hopefully that won't break anything.

Also, I've added myself to ops 😉

## What's Changed

Add WorldEdit and LuckPerms, obtained via Modrinth, to the Minecraft server.

### Type of Change

- [ ] 🆕 New app/service
- [ ] ⬆️ Version upgrade
- [x] 🔧 Config change
- [ ] 🐛 Bug fix
- [ ] 🧹 Cleanup

### Apps/Namespaces Affected

minecraft

### Testing Done

Trust me bro.
