### PR TITLE
🐛 fix(minecraft): Oopsie, Distant Horizons has no release versions, only betas

### DIFF
--- a/kubernetes/apps/default/minecraft/app/helmrelease.yaml
+++ b/kubernetes/apps/default/minecraft/app/helmrelease.yaml
@@ -79,7 +79,7 @@ spec:
         projects:
           - worldedit
           - luckperms
-          - distanthorizons
+          - distanthorizons:beta
   valuesFrom:
     - kind: Secret
       name: *secret


### PR DESCRIPTION
## What's Changed

Tell the Minecraft Helm chart to install a beta version of Distant Horizons.

### Type of Change

- [ ] 🆕 New app/service
- [ ] ⬆️ Version upgrade
- [ ] 🔧 Config change
- [x] 🐛 Bug fix
- [ ] 🧹 Cleanup

### Apps/Namespaces Affected

minecraft

### Testing Done

Surely things will just work this time.