### PR TITLE
Helm charts: Update Kubernetes service URL

### DIFF
--- a/kubernetes/apps/observability/coroot/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/coroot/app/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
           memory: 300Mi
           ephemeral-storage: 200Mi
     externalPrometheus:
-      url: http://vmsingle-vm.observability.svc.cluster.local:8428
+      url: http://vmsingle-vm.observability.svc.cluster.local:8429
     storage:
       className: ceph-block
     clickhouse:


### PR DESCRIPTION
Update Prometheus service URL in Helm chart to use a new port number for testing purposes.

## What's Changed
<!-- Brief description of what you're adding/changing -->

### Type of Change

- [ ] 🆕 New app/service
- [ ] ⬆️ Version upgrade
- [ ] 🔧 Config change
- [ ] 🐛 Bug fix
- [ ] 🧹 Cleanup

### Notes and apps affected
<!-- Which apps or namespaces will this impact? -->
