### PR TITLE
Update CiliumLoadBalancerIPPool CRD schema and version

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/networks.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networks.yaml
@@ -1,6 +1,6 @@
 ---
-# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliumloadbalancerippool_v2alpha1.json
-apiVersion: cilium.io/v2alpha1
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliumloadbalancerippool_v2.json
+apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
   name: pool


### PR DESCRIPTION
Update the YAML schema reference URL and the apiVersion for the
CiliumLoadBalancerIPPool resource from the v2alpha1 CRD/schema to the
stable v2 variant. This aligns the manifest with the newer CRD
definition and ensures the YAML language server validates against the
correct schema.