### PR TITLE
bump rook-ceph chart and migrate Ceph config

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/repository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/repository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.18.9
+    tag: v1.19.3
   url: oci://ghcr.io/rook/rook-ceph

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -30,27 +30,9 @@ spec:
         requests:
           cpu: 50m
           memory: 64Mi
-    configOverride: |
-      [global]
-      bdev_enable_discard = true
-      bdev_async_discard = true
-      osd_class_update_on_start = false
-      # Throttle recovery/backfill to reduce network pressure on 1GbE
-      osd_recovery_max_active = 1
-      osd_max_backfills = 1
-      osd_recovery_sleep = 0.5
-      # Schedule scrubbing overnight (2:00 - 6:00)
-      osd_scrub_begin_hour = 2
-      osd_scrub_end_hour = 6
-      # Reduce scrub impact
-      osd_scrub_sleep = 0.1
-      osd_scrub_priority = 1
-      osd_scrub_chunk_min = 1
-      osd_scrub_chunk_max = 5
-      osd_deep_scrub_interval = 604800
-      # Reduce mon warnings threshold
-      mon_data_avail_warn = 20
-
+    cephImage:
+      repository: quay.io/ceph/ceph
+      tag: v19.2.3
     operatorNamespace: rook-ceph
     route:
       dashboard:
@@ -68,6 +50,29 @@ spec:
             namespace: kube-system
             sectionName: https
     cephClusterSpec:
+      cephConfig:
+        global:
+          bdev_enable_discard: "true"
+          bdev_async_discard: "true"
+          osd_class_update_on_start: "false"
+          # Throttle recovery/backfill to reduce network pressure on 1GbE
+          osd_recovery_max_active: "1"
+          osd_max_backfills: "1"
+          osd_recovery_sleep: "0.5"
+          # Schedule scrubbing overnight (2:00 - 6:00)
+          osd_scrub_begin_hour: "2"
+          osd_scrub_end_hour: "6"
+          # Reduce scrub impact
+          osd_scrub_sleep: "0.1"
+          osd_scrub_priority: "1"
+          osd_scrub_chunk_min: "1"
+          osd_scrub_chunk_max: "5"
+          osd_deep_scrub_interval: "604800"
+          # Reduce mon warnings threshold
+          mon_data_avail_warn: "20"
+      csi:
+        readAffinity:
+          enabled: true
       network:
         provider: host
         connections:
@@ -148,6 +153,10 @@ spec:
           requests:
             cpu: 200m
             memory: 128Mi
+      priorityClassNames:
+        mon: system-node-critical
+        osd: system-node-critical
+        mgr: system-cluster-critical
     cephBlockPoolsVolumeSnapshotClass:
       enabled: true
       name: csi-ceph-blockpool

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/repository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/repository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.18.9
+    tag: v1.19.3
   url: oci://ghcr.io/rook/rook-ceph-cluster

--- a/kubernetes/components/volsync/pvc.yaml
+++ b/kubernetes/components/volsync/pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: "${APP}"
   labels:
+    # IfNotPresent: Flux creates this PVC once and never updates it.
+    # PVC specs are immutable after binding (except storage size).
+    # To resize: kubectl patch pvc <app> -n <ns> --type=merge -p '{"spec":{"resources":{"requests":{"storage":"<new-size>"}}}}'
+    # To restore from backup: delete the PVC and remove this label so Flux recreates it via the ReplicationDestination.
     kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
 spec:
   accessModes: ["${VOLSYNC_ACCESSMODES:=ReadWriteOnce}"]


### PR DESCRIPTION
Update Rook-Ceph chart tags from v1.18.9 to v1.19.3 for both
app and cluster repositories and set the Ceph image to quay.io/ceph/ceph
v19.2.3. Move legacy flat configOverride entries into structured
cephConfig.global keys (string values) and enable CSI read affinity.
Also set priorityClassNames for mon/osd/mgr to ensure critical
scheduling.