### PR TITLE
Use existing PVC for seerr config cache

### DIFF
--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -75,7 +75,7 @@ spec:
         globalMounts:
           - path: /app/config
       config-cache:
-        type: emptyDir
+        existingClaim: seerr-cache
         globalMounts:
           - path: /app/config/cache
       config-logs:


### PR DESCRIPTION
Switch the seerr app's config-cache from an ephemeral emptyDir to an
existing persistent volume claim named `seerr-cache`. This ensures the
cache data persists across pod restarts and rescheduling, preventing
loss of cached configuration and improving reliability.