### PR TITLE
Adjust Minecraft cron scaling window

### DIFF
--- a/kubernetes/apps/default/minecraft/app/scaledobject.yaml
+++ b/kubernetes/apps/default/minecraft/app/scaledobject.yaml
@@ -13,6 +13,6 @@ spec:
     - type: cron
       metadata:
         timezone: Europe/Paris
-        start: 0 6 * * *
-        end: 0 1 * * *
+        start: 0 7 * * *
+        end: 0 3 * * *
         desiredReplicas: "1"


### PR DESCRIPTION
Shift the cron scaling window for the Minecraft app to better match
desired active hours. The start time was moved from 06:00 to 07:00 and
the end time from 01:00 to 03:00 (Europe/Paris), keeping desired
replicas at 1.