### PR TITLE
Increase liveness probe failure threshold

### DIFF
--- a/kubernetes/apps/default/minecraft/app/helmrelease.yaml
+++ b/kubernetes/apps/default/minecraft/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
         - mc-health
       initialDelaySeconds: 60
       periodSeconds: 10
-      failureThreshold: 10
+      failureThreshold: 120 # temporarily increased - SQL migration (DistantHorizons) causes slow startup
       successThreshold: 1
       timeoutSeconds: 5
     readinessProbe:


### PR DESCRIPTION
Temporarily increase the liveness probe failureThreshold from 10 to
120 to accommodate slow startup caused by SQL migration (DistantHorizons).
This prevents premature restarts during the extended initialization period.