### PR TITLE
chore(pre-commit): re-enable sops forbid-secrets hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,10 +25,10 @@ repos:
     rev: 0.6.6
     hooks:
       - id: fix-smartquotes
-  # - repo: https://github.com/k8s-at-home/sops-pre-commit
-  #   rev: v2.1.1
-  #   hooks:
-  #     - id: forbid-secrets
+  - repo: https://github.com/k8s-at-home/sops-pre-commit
+    rev: v2.1.1
+    hooks:
+      - id: forbid-secrets
   - repo: https://github.com/zricethezav/gitleaks
     rev: v8.18.3
     hooks:


### PR DESCRIPTION
> **Merge order: 2 of 3** — safe to merge any time after PR 1 has been observed working. Independent of the Renovate changes.

## What's Changed

Uncomments the `k8s-at-home/sops-pre-commit` `forbid-secrets` hook block in `.pre-commit-config.yaml`. Defense-in-depth alongside the existing `gitleaks` hook — different ruleset that specifically catches unencrypted sops files (e.g. files with a `sops:` stanza but missing the `enc:` marker) that gitleaks's regex-based scanning doesn't reliably flag.

### Type of Change

- [x] 🔧 Config change

### Notes and apps affected

- **No runtime impact** — pre-commit hooks run only at commit time on developer machines and in the `pr-check` workflow.
- No apps affected.

### Verification

Run locally before merging to confirm no false positives on existing committed `.sops.yaml` files:

```sh
pre-commit run forbid-secrets --all-files
```

If the hook flags a real sops file, the rule set may need a tweak — review against https://github.com/k8s-at-home/sops-pre-commit before merge.