### PR TITLE
ci(scorecard): add OpenSSF Scorecard workflow and document supply chain posture

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: OpenSSF Scorecard
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: results.sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,3 +26,30 @@ Thank you 🙏
 > **Note:** Never include actual secret values in a PR.
 > If you discovered exposed credentials, please open an issue or contact me
 > privately instead.
+
+## Supply chain posture
+
+Defenses in place to limit blast radius from compromised upstream packages
+(npm/PyPI rapid-release attacks, malicious GitHub Actions, tag mutation):
+
+- **GitHub Actions are SHA-pinned** via the `helpers:pinGitHubActionDigests`
+  Renovate preset. New actions land unpinned and Renovate replaces version tags
+  with immutable commit SHAs on the next run.
+- **Container images are digest-pinned** by Renovate (`pinDigests: true` for
+  the `docker` datasource). Tag-only references are gradually replaced with
+  `image@sha256:...` form.
+- **3-day release-age cooldown** on auto-merged patches. Gives the community
+  time to revoke a malicious release before it lands here.
+- **Auto-merge deny list** for high-blast-radius components (Plex, Rook-Ceph,
+  Cilium, Talos, Flux operator/instance). These always require manual review.
+- **Renovate vulnerability alerts** surface GHSA advisories as PRs labeled
+  `security` for prioritized review.
+- **Trivy** scans every container referenced in PR-changed YAML and uploads
+  SARIF to the GitHub Security tab.
+- **OpenSSF Scorecard** runs weekly and on push to `main`, flagging repo-level
+  misconfigurations (missing branch protection, dangerous workflow patterns,
+  etc.).
+- **gitleaks** + **sops forbid-secrets** pre-commit hooks catch unencrypted
+  secrets before they reach the index.
+- **Secrets** are encrypted at rest with age via sops; runtime materialization
+  is handled by external-secrets + 1Password Connect.


### PR DESCRIPTION
> **Merge order: 3 of 3** — land this last. SECURITY.md describes the full target supply-chain posture, which is most accurate once the planned `pinDigests` / `minimumReleaseAge` / `vulnerabilityAlerts` follow-up has also landed (a separate small PR will follow).

## What's Changed

Two related changes:

1. **New workflow** `.github/workflows/scorecard.yaml` — runs OpenSSF Scorecard on push to `main`, weekly cron (Monday 06:00 UTC), and on manual dispatch. Publishes SARIF results to the GitHub Security tab so repo-level misconfigurations (missing branch protection, dangerous workflow patterns, untrusted action sources, etc.) surface alongside Trivy findings.
2. **SECURITY.md** — appends a `## Supply chain posture` section documenting the defenses now in place: SHA-pinned actions, digest-pinned images, 3-day release-age cooldown, auto-merge deny list for high-blast-radius apps, Renovate vulnerability alerts, Trivy container scans, Scorecard weekly runs, gitleaks + forbid-secrets pre-commit hooks, and sops + external-secrets for runtime secrets.

### Type of Change

- [x] 🆕 New app/service (Scorecard workflow)
- [x] 🔧 Config change (SECURITY.md update)

### Notes and apps affected

- **No runtime cluster impact** — workflow runs on GitHub Actions only.
- Reuses SHA pins already proven in this repo (`actions/checkout`, `github/codeql-action/upload-sarif`). `ossf/scorecard-action@v2.4.0` and `actions/upload-artifact@v4` are version-tagged for now — Renovate's existing `helpers:pinGitHubActionDigests` preset will SHA-pin them on its next run (within ~1h).

### Verification

1. After merge, check the Actions tab for the first `OpenSSF Scorecard` run (triggered by push to `main`).
2. Confirm SARIF appears at `Security → Code scanning alerts` once the run completes.
3. Within ~1h, expect a Renovate PR pinning the unpinned action SHAs.