### PR TITLE
fix(ci): disable Homebrew Linux sandbox in kubeconform workflow

### DIFF
--- a/.github/workflows/kubeconform.yaml
+++ b/.github/workflows/kubeconform.yaml
@@ -8,6 +8,7 @@ on:
 
 env:
   KUBERNETES_DIR: ./kubernetes
+  HOMEBREW_NO_SANDBOX_LINUX: 1
 
 jobs:
   kubeconform:


### PR DESCRIPTION
> **Urgent** — Kubeconform CI is broken on every PR since #3430. This unblocks PR validation for all in-flight Renovate / feature PRs.

## What's Changed

Adds `HOMEBREW_NO_SANDBOX_LINUX: 1` to the workflow-level `env:` block in `.github/workflows/kubeconform.yaml`.

### Root cause

PR #3430 bumped `Homebrew/actions/setup-homebrew` to the newest revision. That version introduced a Linux sandbox feature that requires a rootless `bwrap` (bubblewrap) executable on `PATH`. GitHub-hosted `ubuntu-latest` runners don't ship bubblewrap, and even installing it via apt isn't a clean fix — the runner's AppArmor profile restricts unprivileged user namespaces, which bubblewrap depends on.

The `brew install` step now fails before any formula is installed:

```
Error: Bubblewrap is required to use the Linux sandbox but was not found.
Install Bubblewrap and ensure a rootless `bwrap` executable is available on `PATH`.
As a final workaround, disable the Linux sandbox:
  export HOMEBREW_NO_SANDBOX_LINUX=1
```

The env var is Homebrew's own documented CI workaround. Scoped at the workflow level so it only affects this one workflow (no other workflows use Homebrew).

### Type of Change

- [x] 🐛 Bug fix

### Notes and apps affected

- **No runtime impact** — CI-only change.
- Affects only the Kubeconform PR check. Other CI workflows are unchanged.
- Trade-off: disables Homebrew's sandboxing during package installation on the runner. Acceptable because the runner is ephemeral and the formulae (`fluxcd/tap/flux`, `kubeconform`, `kustomize`) are from official taps.

### Alternative considered

Installing bubblewrap via `sudo apt-get install -y bubblewrap` before `brew install`. Rejected because bwrap fails on GitHub runners with `setting up uid map: ... Permission denied` under the default AppArmor profile — a known issue tracked in Homebrew/brew#19443 and similar.

### Verification

Once merged, the next PR touching `kubernetes/**` should see the Kubeconform check pass through the `brew install` step. The follow-up `Run kubeconform` step then validates manifests as before.