### PR TITLE
fix(dragonfly): allow port 6379 ingress from all namespaces

### DIFF
--- a/kubernetes/apps/database/dragonfly/cluster/networkpolicy.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/networkpolicy.yaml
@@ -14,6 +14,11 @@ spec:
     - Ingress
   ingress:
     - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 6379
+          protocol: TCP
+    - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: observability


### PR DESCRIPTION
## Problem

The Dragonfly operator creates a restrictive NetworkPolicy that only allows port 6379 access from pods within the `database` namespace. This blocks apps like docmost, paperless, and affine (all in the `default` namespace) from connecting to dragonfly, causing `ETIMEDOUT` / `Timeout connecting to server` errors.

## Fix

Add an ingress rule to the `dragonfly-allow-vmagent` NetworkPolicy allowing TCP port 6379 from all namespaces. Since NetworkPolicies are additive, this complements the operator-created restrictive policy.

## Verification

- docmost pod now starts without Redis connection errors
- Paperless no longer logs `Timeout connecting to server` errors