### PR TITLE
🚀 feat: add tuppr system-upgrade automation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@ Home-ops IaC repo — Kubernetes cluster managed with Flux CD, Talos Linux, and 
 - Apply to each control plane node: `task talos:apply-node IP=192.168.69.110` (repeat for .111, .112).
 - Static pod resources (apiserver, etcd, etc.) live in `talos/patches/controller/`. Always set both `requests` and `limits`.
 - Check for OOM issues: `talosctl -n <node-ip> dmesg | grep -i "oom\|kill"`.
+- Talos/K8s upgrades are automated via [tuppr](https://github.com/home-operations/tuppr) in `system-upgrade` namespace.
+  - Renovate bumps versions in `TalosUpgrade`/`KubernetesUpgrade` CRs — merge the PR, Flux applies, tuppr orchestrates.
+  - Upgrades run during maintenance window (Sunday 02:00 Europe/Paris) with Ceph noout pre/post hooks.
+  - Manual upgrade still possible: `task talos:upgrade-node IP=192.168.69.110`.
 
 ## Secrets
 

--- a/kubernetes/apps/system-upgrade/app/externalsecret.yaml
+++ b/kubernetes/apps/system-upgrade/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tuppr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: tuppr-notification
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        url: "pushover://shoutrrr:{{ .GATUS_PUSHOVER_TOKEN }}@{{ .PUSHOVER_USER_KEY }}/"
+  dataFrom:
+    - extract:
+        key: pushover

--- a/kubernetes/apps/system-upgrade/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/app/helmrelease.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tuppr
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: tuppr
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controller:
+      logLevel: info
+      leaderElection:
+        enabled: true
+      metrics:
+        enabled: true
+        port: 8081
+    webhook:
+      enabled: true
+    notification:
+      enabled: true
+      secretName: tuppr-notification
+      secretKey: url
+    monitoring:
+      serviceMonitor:
+        enabled: true
+        labels:
+          app.kubernetes.io/name: tuppr
+      prometheusRule:
+        enabled: true
+        labels:
+          app.kubernetes.io/name: tuppr
+      dashboards:
+        enabled: true
+        labels:
+          grafana.integreatly.org/grafana: observability
+        grafanaOperator:
+          enabled: true
+          allowCrossNamespaceImport: true
+          matchLabels:
+            dashboards: grafana
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi

--- a/kubernetes/apps/system-upgrade/app/kubernetes-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/app/kubernetes-upgrade.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: KubernetesUpgrade
+metadata:
+  name: kubernetes
+spec:
+  kubernetes:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
+    version: v1.35.0
+  maintenance:
+    windows:
+      - start: "0 2 * * 0"
+        duration: "4h"
+        timezone: "Europe/Paris"
+  healthChecks:
+    - apiVersion: v1
+      kind: Node
+      expr: status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      name: rook-ceph
+      namespace: rook-ceph
+      expr: status.ceph.health in ["HEALTH_OK"]

--- a/kubernetes/apps/system-upgrade/app/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./repository.yaml
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./talos-upgrade.yaml
+  - ./kubernetes-upgrade.yaml

--- a/kubernetes/apps/system-upgrade/app/repository.yaml
+++ b/kubernetes/apps/system-upgrade/app/repository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tuppr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.27
+  url: oci://ghcr.io/home-operations/charts/tuppr

--- a/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
@@ -14,9 +14,6 @@ spec:
     placement: hard
     timeout: 30m
     stage: false
-    priorityClassName: system-node-critical
-  drain:
-    enabled: true
   parallelism: 1
   maintenance:
     windows:

--- a/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: TalosUpgrade
+metadata:
+  name: cluster
+spec:
+  talos:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    version: v1.12.2
+  policy:
+    debug: false
+    force: false
+    rebootMode: default
+    placement: hard
+    timeout: 30m
+    stage: false
+    priorityClassName: system-node-critical
+  drain:
+    enabled: true
+  parallelism: 1
+  maintenance:
+    windows:
+      - start: "0 2 * * 0"
+        duration: "4h"
+        timezone: "Europe/Paris"
+  healthChecks:
+    - apiVersion: v1
+      kind: Node
+      expr: status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      name: rook-ceph
+      namespace: rook-ceph
+      expr: status.ceph.health in ["HEALTH_OK"]
+  hooks:
+    pre:
+      - name: ceph-set-noout
+        image: docker.io/rook/ceph:v1.19.3
+        command:
+          - sh
+          - -c
+        args:
+          - >-
+            printf '[global]\n\tmon_host = %s\n' "$(cat /etc/ceph/mon_host)"
+            > /tmp/ceph.conf &&
+            printf '[client.admin]\n\tkey = %s\n' "$CEPH_SECRET" > /tmp/keyring
+            &&
+            ceph -c /tmp/ceph.conf --keyring /tmp/keyring osd set noout
+        env:
+          - name: CEPH_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: rook-ceph-mon
+                key: ceph-secret
+        volumeMounts:
+          - name: ceph-config
+            mountPath: /etc/ceph
+        volumes:
+          - name: ceph-config
+            secret:
+              secretName: rook-ceph-config
+    post:
+      - name: ceph-unset-noout
+        image: docker.io/rook/ceph:v1.19.3
+        command:
+          - sh
+          - -c
+        args:
+          - >-
+            printf '[global]\n\tmon_host = %s\n' "$(cat /etc/ceph/mon_host)"
+            > /tmp/ceph.conf &&
+            printf '[client.admin]\n\tkey = %s\n' "$CEPH_SECRET" > /tmp/keyring
+            &&
+            ceph -c /tmp/ceph.conf --keyring /tmp/keyring osd unset noout
+        env:
+          - name: CEPH_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: rook-ceph-mon
+                key: ceph-secret
+        volumeMounts:
+          - name: ceph-config
+            mountPath: /etc/ceph
+        volumes:
+          - name: ceph-config
+            secret:
+              secretName: rook-ceph-config

--- a/kubernetes/apps/system-upgrade/ks.yaml
+++ b/kubernetes/apps/system-upgrade/ks.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr
+  namespace: &namespace system-upgrade
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: kube-system
+  path: ./kubernetes/apps/system-upgrade/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/system-upgrade/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: system-upgrade
+components:
+  - ../../components/common
+resources:
+  - ./ks.yaml

--- a/talos/patches/global/machine-features.yaml
+++ b/talos/patches/global/machine-features.yaml
@@ -1,0 +1,8 @@
+machine:
+  features:
+    kubernetesTalosAPIAccess:
+      allowedKubernetesNamespaces:
+        - system-upgrade
+      allowedRoles:
+        - os:admin
+      enabled: true

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -80,6 +80,7 @@ patches:
   - "@./patches/global/machine-network.yaml"
   - "@./patches/global/machine-sysctls.yaml"
   - "@./patches/global/machine-time.yaml"
+  - "@./patches/global/machine-features.yaml"
 
 # Controller patches
 controlPlane:


### PR DESCRIPTION
# PR: Deploy tuppr for automated Talos/K8s upgrades
This PR adds tuppr (https://github.com/home-operations/tuppr) — a Kubernetes controller that automates Talos Linux and Kubernetes upgrades. It replaces the manual task talos:upgrade-node workflow.


## What changed
File
```
talos/patches/global/machine-features.yaml
talos/talconfig.yaml
kubernetes/apps/system-upgrade/kustomization.yaml
kubernetes/apps/system-upgrade/ks.yaml
kubernetes/apps/system-upgrade/app/kustomization.yaml
kubernetes/apps/system-upgrade/app/repository.yaml
kubernetes/apps/system-upgrade/app/helmrelease.yaml
kubernetes/apps/system-upgrade/app/externalsecret.yaml
kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
kubernetes/apps/system-upgrade/app/kubernetes-upgrade.yaml
AGENTS.md
```

How the automated flow works
1. Renovate bumps the TalosUpgrade/KubernetesUpgrade CR version
2. PR merges (auto-merge enabled for area/talos)
3. Flux applies the CR change
4. Tuppr detects new target version
5. Waits for Sunday 02:00 Europe/Paris (maintenance window)
6. Pre-hook: ceph osd set noout (prevents Ceph PG rebalancing)
7. Nodes upgraded one-by-one: health check → drain → upgrade → reboot → uncordon
8. Post-hook: ceph osd unset noout
9. Pushover notification sent on completion
Post-merge manual steps (one-time only)
After merging, apply the Talos API access patch to all 3 nodes:
```
task talos:generate-config
task talos:apply-node IP=192.168.69.110
task talos:apply-node IP=192.168.69.111
task talos:apply-node IP=192.168.69.112
```
Then Flux will deploy tuppr into the system-upgrade namespace automatically. Monitor with:
```
kubectl get pods -n system-upgrade
kubectl get talosupgrade -n system-upgrade -w
kubectl get kubernetesupgrade -n system-upgrade -w
```
To manually trigger an upgrade outside the maintenance window, edit the version in the CR and Flux will apply it - tuppr will start immediately.