### PR TITLE
fix(rook-ceph): work around Cilium Gateway envoy EDS issue with hostNetwork mgr dashboard

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/dashboard-proxy.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/dashboard-proxy.yaml
@@ -1,10 +1,7 @@
 ---
-# Cilium Gateway envoy has an issue proxying via EDS to hostNetwork pods.
-# The rook-ceph-mgr uses hostNetwork, so the mgr dashboard (rook-ceph-mgr-dashboard
-# service) is unreachable through the Gateway. As a workaround, this proxy pod
-# uses regular pod networking (gets a proper CiliumEndpoint) and carries the
-# service selector labels so rook-ceph-mgr-dashboard routes to it instead of the
-# mgr. It forwards / to the mgr dashboard at its host IP.
+# Cilium Gateway envoy can't EDS-proxy to hostNetwork pods (rook-ceph-mgr).
+# This proxy uses regular pod networking so the envoy can reach it, then
+# forwards to the mgr dashboard at its host IP.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,15 +12,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: rook-ceph-mgr
-      mgr_role: active
-      rook_cluster: rook-ceph
+      app.kubernetes.io/name: rook-ceph-dashboard-proxy
   template:
     metadata:
       labels:
-        app: rook-ceph-mgr
-        mgr_role: active
-        rook_cluster: rook-ceph
+        app.kubernetes.io/name: rook-ceph-dashboard-proxy
     spec:
       containers:
         - name: nginx
@@ -65,3 +58,40 @@ data:
             proxy_set_header X-Real-IP $remote_addr;
         }
     }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rook-ceph-dashboard-proxy
+  annotations:
+    glance/description: Rook Ceph Dashboard
+    glance/icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/rook.png
+    glance/name: Rook Ceph
+    glance/show: "true"
+spec:
+  selector:
+    app.kubernetes.io/name: rook-ceph-dashboard-proxy
+  ports:
+    - port: 7000
+      targetPort: 7000
+      name: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: rook-ceph-dashboard
+spec:
+  hostnames:
+    - rook.juno.moe
+  parentRefs:
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: rook-ceph-dashboard-proxy
+          port: 7000
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -39,23 +39,8 @@ spec:
       repository: quay.io/ceph/ceph
       tag: v19.2.4
     operatorNamespace: rook-ceph
-    # Cilium Gateway envoy can't EDS-proxy to hostNetwork pods (mgr). The
-    # dashboard-proxy deployment below intercepts the service selector instead.
-    route:
-      dashboard:
-        annotations:
-          glance/show: "true"
-          glance/name: Rook Ceph
-          glance/icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/rook.png
-          glance/description: Rook Ceph Dashboard
-        host:
-          name: rook.juno.moe
-          path: /
-          pathType: PathPrefix
-        parentRefs:
-          - name: internal
-            namespace: kube-system
-            sectionName: https
+    # Route is managed by a separate HTTPRoute (dashboard-proxy) instead of the
+    # Helm chart, because Cilium Gateway envoy can't EDS-proxy to hostNetwork pods.
     cephClusterSpec:
       cephConfig:
         global:


### PR DESCRIPTION
The Cilium Gateway envoy times out when proxying via EDS to hostNetwork
pods. Since rook-ceph-mgr uses hostNetwork, the dashboard was unreachable
(503 upstream connection timeout).

- Deploy an nginx proxy pod with regular pod networking (proper CiliumEndpoint)
- Create a dedicated Service + HTTPRoute pointing to the proxy
- Proxy forwards / to the mgr dashboard at its host IP
- Remove Helm-generated route (route.dashboard) to avoid conflicting HTTPRoutes
- Remove mgr nodeAffinity restriction (wasn't the root cause)

Also removes the stale test-ceph-health pod (was connecting to wrong IP)