### PR TITLE
fix(talos): raise kube-apiserver memory limits from 2Gi to 3Gi

### DIFF
--- a/talos/patches/controller/apiserver-resources.yaml
+++ b/talos/patches/controller/apiserver-resources.yaml
@@ -3,6 +3,6 @@ cluster:
     resources:
       requests:
         cpu: 200m
-        memory: 512Mi
+        memory: 1Gi
       limits:
-        memory: 2Gi
+        memory: 3Gi


### PR DESCRIPTION
Requests increased from 512Mi to 1Gi, limits from 2Gi to 3Gi.

Two of three apiservers were running at 94% of the 2Gi limit
(k8s-1: 1783Mi, k8s-2: 1933Mi). Root causes:
- 169 CRDs each adding schema, watch cache, and OpenAPI overhead
- Stale Intel device plugin webhooks generating continuous errors
- 501K openapi/v3 serialization requests over 28d uptime

Also cleaned up 10 unused Intel CRDs + 17 dead webhooks
from the cluster to stop admission errors and reduce watch
pressure.