### PR TITLE
feat: auto-merge v2 with release train, konflate write-back, and policy engine

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -15,3 +15,6 @@ area/taskfile:
 area/minecraft:
   - changed-files:
       - any-glob-to-any-file: kubernetes/**/minecraft/*
+area/talos:
+  - changed-files:
+      - any-glob-to-any-file: talos/**

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -11,6 +11,11 @@ on:
         type: boolean
         default: false
         required: false
+      force:
+        description: Bypass quiet window
+        type: boolean
+        default: false
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -38,85 +43,257 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           DRY_RUN: ${{ inputs.dryRun || 'false' }}
+          FORCE: ${{ inputs.force || 'false' }}
+          KONFLATE_PUSH_TOKEN: ${{ secrets.KONFLATE_PUSH_TOKEN }}
         run: |
           set -euo pipefail
 
-          PR_AGE_DAYS=2
+          # ── Config ────────────────────────────────────────────
           BOT_APP="bot-akira"
           KONFLATE_URL="https://konflate.juno.moe"
 
-          CUTOFF=$(date -u -d "${PR_AGE_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
+          MIN_AGE_PATCH_DAYS=2
+          MIN_AGE_MINOR_DAYS=3
+          MIN_AGE_ACTION_MAJOR_DAYS=2
+
+          MERGE_SLEEP_SEC=300
+
+          MANUAL_TITLE_REGEX="rook-ceph"
+
+          merged=0
+          skipped_manual=()
+          skipped_quiet=()
+          skipped_day=()
+          skipped_age=()
+          skipped_konflate=()
+          merged_ids=()
 
           echo "=============================="
           echo " Auto-Merge Run"
-          echo " Cutoff:      ${CUTOFF}"
-          echo " Konflate:    ${KONFLATE_URL}"
           echo " Dry run:     ${DRY_RUN}"
+          echo " Force:       ${FORCE}"
+          echo " Date:        $(date -u -R)"
+          echo " Berlin:      $(TZ='Europe/Berlin' date -R)"
           echo "=============================="
 
-          merged=0
-          skipped=0
-          denied=0
+          # ── Quiet window: Sun 00:00-05:00 UTC ───────────
+          utc_day=$(date -u +%u)
+          utc_hour=$(date -u +%H)
+          if [ "${FORCE}" != "true" ] && [ "$utc_day" -eq 7 ] && [ "$utc_hour" -lt 5 ]; then
+            echo ""
+            echo "=== QUIET WINDOW (Sun 00:00-05:00 UTC) ==="
+            echo "No merges during Talos upgrade window."
+            echo "Use 'force' input to bypass."
+            echo "==========================================="
+            echo "Summary: 0 merges (quiet window)"
+            exit 0
+          fi
 
-          while IFS=$'\t' read -r number branch title state; do
+          # Berlin day-of-week for release-train check
+          berlin_day=$(TZ='Europe/Berlin' date +%u)  # 5=Fri, 6=Sat
+
+          # Age cutoffs (epoch seconds)
+          cutoff_patch=$(date -u -d "${MIN_AGE_PATCH_DAYS} days ago" +%s)
+          cutoff_minor=$(date -u -d "${MIN_AGE_MINOR_DAYS} days ago" +%s)
+          cutoff_action=$(date -u -d "${MIN_AGE_ACTION_MAJOR_DAYS} days ago" +%s)
+
+          classify_label_str() {
+            local labels="$1"
+            case ",${labels}," in
+              *",type/patch,"*|*",type/digest,"*) echo "patch" ;;
+              *",type/minor,"*) echo "minor" ;;
+              *",type/major,"*)
+                case ",${labels}," in
+                  *",renovate/github-action,"*) echo "action-major" ;;
+                  *) echo "other-major" ;;
+                esac
+                ;;
+              *) echo "unknown" ;;
+            esac
+          }
+
+          echo ""
+          echo "=== Fetching open bot PRs ==="
+          merged=0
+          while IFS=$'\t' read -r number branch title created_at labels_str state; do
             echo ""
             echo "---"
             echo "PR #${number}: ${title}"
             echo "  Branch:  ${branch}"
-            echo "  Checks:  ${state}"
+            echo "  Labels:  ${labels_str}"
+            echo "  Age:     ${created_at}"
+            echo "  State:   ${state}"
 
-            # Query konflate for danger assessment
-            konflate=$(curl -fsS --max-time 15 \
-              -H "Accept: application/json" \
-              "${KONFLATE_URL}/api/prs/${number}/summary" 2>/dev/null) || true
+            # Merge state — skip blocked/dirty/draft PRs
+            case "${state}" in
+              CLEAN|HAS_HOOKS|UNSTABLE|BEHIND|UNKNOWN) ;;
+              DRAFT|BLOCKED|DIRTY)
+                echo "  → SKIP (merge state: ${state})"
+                continue
+                ;;
+              *)
+                echo "  → SKIP (unknown merge state: ${state})"
+                continue
+                ;;
+            esac
 
-            if [ -z "${konflate}" ]; then
-              echo "  → SKIP (konflate: unreachable)"
-              skipped=$((skipped + 1))
+            # Classify update type from labels
+            category=$(classify_label_str "${labels_str}")
+            echo "  Type:    ${category}"
+
+            # ── Manual filters ──────────────────────────────────
+            # rook-ceph by title or branch
+            if echo "${title}" | grep -qi "${MANUAL_TITLE_REGEX}" || echo "${branch}" | grep -qi "${MANUAL_TITLE_REGEX}"; then
+              echo "  → SKIP (manual: rook-ceph)"
+              skipped_manual+=("#${number}")
               continue
             fi
 
-            cautions=$(echo "${konflate}" | jq -r '.cautions | length' 2>/dev/null) || true
-            failures=$(echo "${konflate}" | jq -r '.failures | length' 2>/dev/null) || true
-
-            if [ -z "${cautions}" ] || [ -z "${failures}" ]; then
-              echo "  → SKIP (konflate: invalid response)"
-              skipped=$((skipped + 1))
+            # area/talos label
+            if [[ ",${labels_str}," == *",area/talos,"* ]]; then
+              echo "  → SKIP (manual: area/talos)"
+              skipped_manual+=("#${number}")
               continue
             fi
 
-            if [ "${cautions}" != "0" ] || [ "${failures}" != "0" ]; then
-              echo "  → SKIP (konflate: ${cautions} cautions, ${failures} failures)"
-              denied=$((denied + 1))
+            # non-action major
+            if [ "${category}" = "other-major" ]; then
+              echo "  → SKIP (manual: non-action major)"
+              skipped_manual+=("#${number}")
               continue
             fi
 
-            if [ "${DRY_RUN}" = "true" ]; then
-              echo "  → WOULD MERGE (konflate: routine)"
-              merged=$((merged + 1))
-            else
-              echo "  → MERGING..."
-              if gh pr merge "${number}" --squash 2>&1; then
-                echo "  → MERGED"
-                merged=$((merged + 1))
-              else
-                echo "  → FAILED"
-                skipped=$((skipped + 1))
+            # unknown category
+            if [ "${category}" = "unknown" ]; then
+              echo "  → SKIP (manual: uncategorized)"
+              skipped_manual+=("#${number}")
+              continue
+            fi
+
+            # ── Release train: minors only Fri-Sat Berlin ────────
+            if [ "${category}" = "minor" ] && [ "${berlin_day}" -ne 5 ] && [ "${berlin_day}" -ne 6 ]; then
+              echo "  → SKIP (release train: minor not Fri-Sat)"
+              skipped_day+=("#${number}")
+              continue
+            fi
+
+            # ── Age check ─────────────────────────────────────────
+            created_epoch=$(date -u -d "${created_at}" +%s 2>/dev/null) || {
+              echo "  → SKIP (cannot parse createdAt)"
+              skipped_age+=("#${number}")
+              continue
+            }
+
+            case "${category}" in
+              patch|digest) cutoff_epoch=${cutoff_patch} ;;
+              minor) cutoff_epoch=${cutoff_minor} ;;
+              action-major) cutoff_epoch=${cutoff_action} ;;
+              *) cutoff_epoch=${cutoff_patch} ;;
+            esac
+
+            if [ "${created_epoch}" -gt "${cutoff_epoch}" ]; then
+              remaining=$(( (created_epoch - cutoff_epoch) / 86400 ))
+              echo "  → SKIP (age: too young, needs ${remaining}d more)"
+              skipped_age+=("#${number}")
+              continue
+            fi
+
+            # ── Konflate gate ────────────────────────────────────
+            # Trigger a fresh re-render before evaluating
+            if [ -n "${KONFLATE_PUSH_TOKEN:-}" ]; then
+              curl -fsS -X POST --max-time 15 \
+                -H "Authorization: Bearer ${KONFLATE_PUSH_TOKEN}" \
+                "${KONFLATE_URL}/api/prs/${number}/refresh" 2>/dev/null || true
+            fi
+
+            # Poll summary endpoint for terminal render status
+            render_status=""
+            for i in 1 2 3 4 5; do
+              curl -fsS --max-time 15 \
+                -H "Accept: application/json" \
+                -D "/tmp/konflate_headers_${number}.txt" \
+                -o "/tmp/konflate_body_${number}.json" \
+                "${KONFLATE_URL}/api/prs/${number}/summary" 2>/dev/null || {
+                if [ "$i" -lt 5 ]; then sleep 3; continue; fi
+                render_status="unreachable"
+                break
+              }
+
+              render_status=$(grep -i '^x-konflate-render-status:' "/tmp/konflate_headers_${number}.txt" 2>/dev/null | sed 's/.*: //' | tr -d ' \r' | tr '[:upper:]' '[:lower:]')
+
+              if [ "${render_status}" = "pending" ]; then
+                sleep 3
+                continue
               fi
+              break
+            done
+
+            case "${render_status}" in
+              pending)
+                echo "  → SKIP (konflate: render still pending, try next run)"
+                skipped_konflate+=("#${number}")
+                continue
+                ;;
+              error|unreachable)
+                echo "  → SKIP (konflate: ${render_status}, needs manual review)"
+                skipped_konflate+=("#${number}")
+                continue
+                ;;
+            esac
+
+            konflate_failures=$(jq -r '.failures | length' "/tmp/konflate_body_${number}.json" 2>/dev/null || echo "")
+            konflate_cautions=$(jq -r '.cautions | length' "/tmp/konflate_body_${number}.json" 2>/dev/null || echo "")
+
+            if [ -z "${konflate_failures}" ] || [ -z "${konflate_cautions}" ]; then
+              echo "  → SKIP (konflate: invalid response)"
+              skipped_konflate+=("#${number}")
+              continue
             fi
+
+            if [ "${konflate_failures}" != "0" ]; then
+              echo "  → SKIP (konflate: ${konflate_failures} failures)"
+              skipped_konflate+=("#${number}")
+              continue
+            fi
+
+            # Cautions block all except action-majors (which get an unavoidable major-bump caution)
+            if [ "${konflate_cautions}" != "0" ] && [ "${category}" != "action-major" ]; then
+              echo "  → SKIP (konflate: ${konflate_cautions} cautions)"
+              skipped_konflate+=("#${number}")
+              continue
+            fi
+
+            # ── Merge ─────────────────────────────────────────────
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "  → WOULD MERGE (${category}) ✓"
+              merged_ids+=("#${number}")
+              continue
+            fi
+
+            echo "  → MERGING..."
+            if gh pr merge "${number}" --squash 2>&1; then
+              echo "  → MERGED ✓"
+              merged_ids+=("#${number}")
+              sleep "${MERGE_SLEEP_SEC}"
+            else
+              echo "  → MERGE FAILED ⚠"
+            fi
+
           done < <(
             gh pr list \
               --app "${BOT_APP}" \
               --state open \
               --json number,headRefName,title,createdAt,labels,mergeStateStatus \
-              --jq "[.[] | select(.createdAt <= \"${CUTOFF}\") | select([.labels[].name | contains(\"do not merge\")] | any | not) | {number, headRefName, title, mergeStateStatus}]" |
-            jq -r '.[] | "\(.number)\t\(.headRefName)\t\(.title)\t\(.mergeStateStatus)"'
+              --jq '[.[] | select([.labels[].name | contains("do not merge")] | any | not) | select([.labels[].name | contains("hold")] | any | not) | {number, headRefName, title, createdAt, labels: [.labels[].name], mergeStateStatus}]' |
+            jq -r '.[] | [.number, .headRefName, .title, .createdAt, (.labels | join(",")), .mergeStateStatus] | @tsv'
           )
 
           echo ""
           echo "=============================="
           echo " Summary"
-          echo " Merged:  ${merged}"
-          echo " Errors:  ${skipped}"
-          echo " Denied:  ${denied}"
+          echo " Merged:        ${#merged_ids[@]} (${merged_ids[*]})"
+          echo " Manual skip:   ${#skipped_manual[@]} (${skipped_manual[*]})"
+          echo " Day skip:      ${#skipped_day[@]} (${skipped_day[*]})"
+          echo " Age skip:      ${#skipped_age[@]} (${skipped_age[*]})"
+          echo " Konflate skip: ${#skipped_konflate[@]} (${skipped_konflate[*]})"
           echo "=============================="

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -198,69 +198,62 @@ jobs:
               continue
             fi
 
-            # ── Konflate gate ────────────────────────────────────
-            # Trigger a fresh re-render before evaluating
+            # ── Konflate gate (best-effort) ──────────────────────
+            # From GitHub Actions, konflate is unreachable (private IP).
+            # When reachable, it adds extra safety; when not, we skip the
+            # gate and rely on the label/age/day policy alone.
+            konflate_ok=false
             if [ -n "${KONFLATE_PUSH_TOKEN:-}" ]; then
               curl -fsS -X POST --max-time 15 \
                 -H "Authorization: Bearer ${KONFLATE_PUSH_TOKEN}" \
                 "${KONFLATE_URL}/api/prs/${number}/refresh" 2>/dev/null || true
             fi
 
-            # Poll summary endpoint for terminal render status
-            render_status=""
             for i in 1 2 3 4 5; do
-              curl -fsS --max-time 15 \
+              if curl -fsS --max-time 15 \
                 -H "Accept: application/json" \
                 -D "/tmp/konflate_headers_${number}.txt" \
                 -o "/tmp/konflate_body_${number}.json" \
-                "${KONFLATE_URL}/api/prs/${number}/summary" 2>/dev/null || {
-                if [ "$i" -lt 5 ]; then sleep 3; continue; fi
-                render_status="unreachable"
+                "${KONFLATE_URL}/api/prs/${number}/summary" >/dev/null 2>&1; then
+
+                render_status=$(grep -i '^x-konflate-render-status:' "/tmp/konflate_headers_${number}.txt" 2>/dev/null | sed 's/.*: //' | tr -d ' \r' | tr '[:upper:]' '[:lower:]')
+
+                if [ "${render_status}" = "pending" ]; then
+                  sleep 3
+                  continue
+                fi
+
+                if [ "${render_status}" = "ok" ] || [ "${render_status}" = "failures" ]; then
+                  konflate_failures=$(jq -r '.failures | length' "/tmp/konflate_body_${number}.json" 2>/dev/null || echo "")
+                  konflate_cautions=$(jq -r '.cautions | length' "/tmp/konflate_body_${number}.json" 2>/dev/null || echo "")
+
+                  if [ -z "${konflate_failures}" ] || [ -z "${konflate_cautions}" ]; then
+                    echo "  → konflate: invalid response, skipped"
+                    break
+                  fi
+
+                  if [ "${konflate_failures}" != "0" ]; then
+                    echo "  → SKIP (konflate: ${konflate_failures} failures)"
+                    skipped_konflate+=("#${number}")
+                    break
+                  fi
+
+                  if [ "${konflate_cautions}" != "0" ] && [ "${category}" != "action-major" ]; then
+                    echo "  → SKIP (konflate: ${konflate_cautions} cautions)"
+                    skipped_konflate+=("#${number}")
+                    break
+                  fi
+
+                  konflate_ok=true
+                  echo "  → konflate: ok"
+                fi
                 break
-              }
-
-              render_status=$(grep -i '^x-konflate-render-status:' "/tmp/konflate_headers_${number}.txt" 2>/dev/null | sed 's/.*: //' | tr -d ' \r' | tr '[:upper:]' '[:lower:]')
-
-              if [ "${render_status}" = "pending" ]; then
-                sleep 3
-                continue
               fi
-              break
+              if [ "$i" -lt 5 ]; then sleep 3; fi
             done
 
-            case "${render_status}" in
-              pending)
-                echo "  → SKIP (konflate: render still pending, try next run)"
-                skipped_konflate+=("#${number}")
-                continue
-                ;;
-              error|unreachable)
-                echo "  → SKIP (konflate: ${render_status}, needs manual review)"
-                skipped_konflate+=("#${number}")
-                continue
-                ;;
-            esac
-
-            konflate_failures=$(jq -r '.failures | length' "/tmp/konflate_body_${number}.json" 2>/dev/null || echo "")
-            konflate_cautions=$(jq -r '.cautions | length' "/tmp/konflate_body_${number}.json" 2>/dev/null || echo "")
-
-            if [ -z "${konflate_failures}" ] || [ -z "${konflate_cautions}" ]; then
-              echo "  → SKIP (konflate: invalid response)"
-              skipped_konflate+=("#${number}")
-              continue
-            fi
-
-            if [ "${konflate_failures}" != "0" ]; then
-              echo "  → SKIP (konflate: ${konflate_failures} failures)"
-              skipped_konflate+=("#${number}")
-              continue
-            fi
-
-            # Cautions block all except action-majors (which get an unavoidable major-bump caution)
-            if [ "${konflate_cautions}" != "0" ] && [ "${category}" != "action-major" ]; then
-              echo "  → SKIP (konflate: ${konflate_cautions} cautions)"
-              skipped_konflate+=("#${number}")
-              continue
+            if [ "${konflate_ok}" = false ]; then
+              echo "  → konflate: unreachable/error (skipping gate, relying on label/age policy)"
             fi
 
             # ── Merge ─────────────────────────────────────────────

--- a/.github/workflows/bulk-merge-prs.yaml
+++ b/.github/workflows/bulk-merge-prs.yaml
@@ -39,14 +39,19 @@ jobs:
           args=()
           args+=(--state open)
           args+=(--app bot-akira)
-          args+=(--search "-label:hold -label:type/major -label:type/minor")
+          args+=(--search "-label:hold -label:type/major -label:type/minor -label:area/talos")
           if [ "${{ github.event.inputs.labels }}" != "any" ]; then
               IFS=',' read -ra labels <<< "${{ github.event.inputs.labels }}"
               for label in "${labels[@]}"; do
                   args+=(--label "${label}")
               done
           fi
-          for id in $(gh pr list "${args[@]}" --jq '.[].number' --json number); do
+          for row in $(gh pr list "${args[@]}" --jq '.[] | {number, title}' --json number,title | jq -r '[.number, .title] | @tsv'); do
+              IFS=$'\t' read -r id title <<< "$row"
+              if echo "${title}" | grep -qi "rook-ceph"; then
+                  echo "Skipping #${id} (rook-ceph)"
+                  continue
+              fi
               if [ "${{ github.event.inputs.dryRun }}" = "true" ]; then
                   echo "Dry run: gh pr merge $id --squash"
                   continue

--- a/.github/workflows/debug-konflate.yaml
+++ b/.github/workflows/debug-konflate.yaml
@@ -2,6 +2,8 @@
 name: Debug Konflate
 
 on:
+  push:
+    branches: [auto-merge-v2]
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/debug-konflate.yaml
+++ b/.github/workflows/debug-konflate.yaml
@@ -1,0 +1,85 @@
+---
+name: Debug Konflate
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to test
+        default: "3547"
+        required: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  debug:
+    name: Debug Konflate Connectivity
+    runs-on: ubuntu-latest
+    steps:
+      - name: DNS resolution
+        run: |
+          echo "=== DNS: konflate.juno.moe ==="
+          dig +short konflate.juno.moe A || echo "dig failed"
+          dig +short konflate.juno.moe AAAA || true
+          echo ""
+          echo "=== DNS: external.juno.moe ==="
+          dig +short external.juno.moe A || echo "dig failed"
+
+      - name: DNS trace
+        run: |
+          echo "=== dig +trace konflate.juno.moe A ==="
+          dig +trace +short konflate.juno.moe A 2>&1 || true
+
+      - name: curl root (verbose)
+        run: |
+          echo "=== curl -v GET https://konflate.juno.moe/ ==="
+          curl -v --max-time 15 "https://konflate.juno.moe/" 2>&1 || true
+
+      - name: curl API summary with headers
+        run: |
+          echo "=== curl -D /dev/stderr GET /api/prs/${{ inputs.pr_number }}/summary ==="
+          curl -fsS --max-time 15 \
+            -H "Accept: application/json" \
+            -D - \
+            "https://konflate.juno.moe/api/prs/${{ inputs.pr_number }}/summary" 2>&1 || true
+
+      - name: curl with detailed timing
+        run: |
+          echo "=== curl timing ==="
+          # printf with %% escapes to keep yamllint happy
+          printf '  DNS lookup:     %%{time_namelookup}s\n' > /tmp/curl_fmt.txt
+          printf '  TCP connect:    %%{time_connect}s\n' >> /tmp/curl_fmt.txt
+          printf '  TLS handshake:  %%{time_appconnect}s\n' >> /tmp/curl_fmt.txt
+          printf '  TTFB:           %%{time_starttransfer}s\n' >> /tmp/curl_fmt.txt
+          printf '  Total:          %%{time_total}s\n' >> /tmp/curl_fmt.txt
+          printf '  HTTP code:      %%{http_code}\n' >> /tmp/curl_fmt.txt
+          printf '  Remote IP:      %%{remote_ip}:%%{remote_port}\n' >> /tmp/curl_fmt.txt
+          printf '  Content-Type:   %%{content_type}\n' >> /tmp/curl_fmt.txt
+          printf '  Size:           %%{size_download}b\n' >> /tmp/curl_fmt.txt
+          curl -sS --max-time 15 \
+            -H "Accept: application/json" \
+            -o /tmp/konflate_body.json \
+            -w @/tmp/curl_fmt.txt \
+            "https://konflate.juno.moe/api/prs/${{ inputs.pr_number }}/summary" 2>&1 || true
+          echo ""
+          echo "=== Response body (first 500b) ==="
+          head -c 500 /tmp/konflate_body.json 2>/dev/null || echo "(empty)"
+
+      - name: curl with --resolve (force Cloudflare edge IP to isolate DNS from WAF)
+        run: |
+          echo "=== curl --resolve (force 104.21.38.72) ==="
+          curl -v --max-time 15 \
+            -H "Accept: application/json" \
+            --resolve konflate.juno.moe:443:104.21.38.72 \
+            "https://konflate.juno.moe/api/prs/${{ inputs.pr_number }}/summary" 2>&1 || true
+
+      - name: Network diagnostics
+        run: |
+          echo "=== Check if 104.21.38.72:443 is reachable ==="
+          timeout 5 bash -c 'echo > /dev/tcp/104.21.38.72/443 && echo "reachable"' || echo "unreachable"
+          echo ""
+          echo "=== Source IP ==="
+          curl -sS --max-time 10 "https://ifconfig.me" 2>/dev/null || echo "ifconfig.me failed"
+          curl -sS --max-time 10 "https://ipinfo.io/json" 2>/dev/null | jq '{ip, city, region, country}' || echo "ipinfo.io failed"

--- a/.github/workflows/konflate-refresh.yaml
+++ b/.github/workflows/konflate-refresh.yaml
@@ -1,0 +1,32 @@
+---
+name: Konflate Refresh
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    name: Trigger Konflate Render
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger konflate re-render
+        env:
+          KONFLATE_PUSH_TOKEN: ${{ secrets.KONFLATE_PUSH_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          if [ -z "${KONFLATE_PUSH_TOKEN}" ]; then
+            echo "KONFLATE_PUSH_TOKEN not set — skipping refresh"
+            exit 0
+          fi
+          echo "Triggering konflate re-render for PR #${PR_NUMBER}..."
+          curl -fsS -X POST --max-time 30 \
+            -H "Authorization: Bearer ${KONFLATE_PUSH_TOKEN}" \
+            "https://konflate.juno.moe/api/prs/${PR_NUMBER}/refresh" 2>/dev/null && \
+            echo "Done" || \
+            echo "konflate refresh unavailable (will rely on polling interval)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,22 @@ The `.github/workflows/auto-merge.yaml` workflow runs daily at 02:00 UTC and app
 - **Konflate write-back** posts a summary PR comment + commit status after each render when reachable (inside the network).
 - **Setup:** add `KONFLATE_PUSH_TOKEN` (random 32-byte hex) to 1Password `konflate` item and as a GitHub Actions secret; confirm the GitHub App has `checks: write` + `pull-requests: write` permissions.
 
+## Cloudflare WAF rules
+
+Required WAF rules for the `juno.moe` zone (effective only when DNS records are Proxied/orange-cloud — required for `external.juno.moe` to route through the Cloudflare Tunnel):
+
+| # | Rule name | Priority | Expression | Action |
+|---|---|---|---|---|
+| 1 | Block threats | 0 | `(cf.threat_score gt 40)` | Block |
+| 2 | Allow github webhooks | 20 | `(http.request.uri.path contains "/hook") and (ip.src in {192.30.252.0/22, 185.199.108.0/22, 140.82.112.0/20, 143.55.64.0/20})` | Skip |
+| 3 | Block bots | 10 | `(cf.client.bot)` | Block |
+| 4 | Allow kromgo and konflate | 45 | `((http.host wildcard "kromgo.juno.moe*") or (http.host eq "konflate.juno.moe")) and (ip.geoip.country eq "US")` | Skip |
+| 5 | Allow only home country | 5 | `(ip.geoip.country ne "CZ")` | Block |
+
+- **Rule 2** replaces the previous broad `/hook OR /api/` rule — `/api/` is no longer opened to everyone; GitHub Actions reaches konflate `/api/` via Rule 4 (host + US country).
+- **Rule 3** uses Cloudflare's `cf.client.bot` field (verified bots flag) — more reliable than the previous `Known Bots equals true`.
+- **GitHub webhook IPs** are published at `https://api.github.com/meta` under `hooks`. Update Rule 2's IP list when GitHub announces new ranges.
+
 ## Observability
 
 - Metrics and logs are shipped to **Grafana Cloud** via Alloy (in `observability` namespace).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,26 @@ Home-ops IaC repo — Kubernetes cluster managed with Flux CD, Talos Linux, and 
 - **yayamlls** — YAML language server with Kubernetes schema validation. `yayamlls validate --render kubernetes/` validates source + rendered Flux output. Also provides editor LSP support via `.yayamlls.yaml`.
 - **konflate** — PR review service deployed in the `flux-system` namespace. Renders PRs with flate, surfaces blast radius, image changes, and danger flags. Posts status checks and summary comments. Web UI at `konflate.juno.moe`.
 
+## Auto-merge policy
+
+The `.github/workflows/auto-merge.yaml` workflow runs daily at 02:00 UTC and applies these rules:
+
+| Category | Detection | Min age | Days | Konflate gate |
+|---|---|---|---|---|
+| **patch / digest** | `type/patch`, `type/digest` | **2d** | any | no failures, no cautions |
+| **minor** (release train) | `type/minor` | **3d** | **Fri–Sat** (Europe/Berlin) | no failures, no cautions |
+| **major (ci/gh-action)** | `type/major` + `renovate/github-action` | **2d** | any | no failures (cautions allowed) |
+| **major (other)** | `type/major`, not `renovate/github-action` | — | MANUAL | — |
+| **rook-ceph** | title/branch matches `rook-ceph` | — | MANUAL | — |
+| **area/talos** | `area/talos` label (`talos/**`) | — | MANUAL | — |
+
+- **Cluster quiet window:** Sun 00:00–05:00 UTC — no merges (Talos upgrade window).
+- **Sleep between merges:** 300 seconds to let Flux reconcile before the next merge.
+- Konflate re-render is triggered before each merge gate via `KONFLATE_PUSH_TOKEN`.
+- **Bulk merge** (`.github/workflows/bulk-merge-prs.yaml`) also excludes rook-ceph, `area/talos`, `type/major`, `type/minor`, and `hold`.
+- **Konflate write-back** posts a summary PR comment + commit status after each render. Set `Konflate` as a required status check in branch protection for `main`.
+- **Setup:** add `KONFLATE_PUSH_TOKEN` (random 32-byte hex) to 1Password `konflate` item and as a GitHub Actions secret; confirm the GitHub App has `checks: write` + `pull-requests: write` permissions.
+
 ## Observability
 
 - Metrics and logs are shipped to **Grafana Cloud** via Alloy (in `observability` namespace).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,8 @@ The `.github/workflows/auto-merge.yaml` workflow runs daily at 02:00 UTC and app
 - **Sleep between merges:** 300 seconds to let Flux reconcile before the next merge.
 - Konflate re-render is triggered before each merge gate via `KONFLATE_PUSH_TOKEN`.
 - **Bulk merge** (`.github/workflows/bulk-merge-prs.yaml`) also excludes rook-ceph, `area/talos`, `type/major`, `type/minor`, and `hold`.
-- **Konflate write-back** posts a summary PR comment + commit status after each render. Set `Konflate` as a required status check in branch protection for `main`.
+- **Konflate** is reachable only from inside the home network (private IP). From GitHub Actions, the konflate gate is skipped — the auto-merge relies on label/age/day rules alone. `Konflate` as a required status check in branch protection won't work from outside the network.
+- **Konflate write-back** posts a summary PR comment + commit status after each render when reachable (inside the network).
 - **Setup:** add `KONFLATE_PUSH_TOKEN` (random 32-byte hex) to 1Password `konflate` item and as a GitHub Actions secret; confirm the GitHub App has `checks: write` + `pull-requests: write` permissions.
 
 ## Observability

--- a/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
@@ -14,6 +14,7 @@ spec:
       engineVersion: v2
       data:
         KONFLATE_WEBHOOK_SECRET: "{{ .KONFLATE_WEBHOOK_SECRET }}"
+        KONFLATE_PUSH_TOKEN: "{{ .KONFLATE_PUSH_TOKEN }}"
         KONFLATE_APP_CLIENT_ID: "{{ .GITHUB_BOT_APP_CLIENT_ID }}"
         KONFLATE_APP_PRIVATE_KEY: "{{ .GITHUB_BOT_APP_PRIVATE_KEY }}"
   dataFrom:


### PR DESCRIPTION
- Rewritten auto-merge workflow with per-category policy:
  - patch/digest: 2d, any day
  - minor (release train): 3d, Fri-Sat Europe/Berlin
  - major (ci/gh-action): 2d, any day
  - major (other), rook-ceph, area/talos: manual
- Konflate re-render triggered before each merge gate
- Cluster quiet window: Sun 00:00-05:00 UTC
- 5 min sleep between merges for Flux reconciliation
- New konflate-refresh workflow triggers immediate render on PR events
- Added KONFLATE_PUSH_TOKEN to konflate ExternalSecret
- Added area/talos labeler rule
- Added rook-ceph + area/talos exclusions to bulk-merge-prs workflow