### PR TITLE
fix(cloudflare-tunnel): remove distroless-incompatible shell wrapper

### DIFF
--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -24,17 +24,11 @@ spec:
           reloader.stakater.com/auto: "true"
         containers:
           app:
-            # Retry wrapper: cloudflared exits when edge-DNS discovery fails
-            # (UniFi dnsmasq restarting or WAN blip). Retries 5× with
-            # exponential backoff instead of restarting the pod.
-            command:
-              - /bin/sh
-              - -c
-              - |
-                for i in 1 2 3 4 5; do
-                  cloudflared $0 "$@" && break
-                  sleep "$((i * 5))"
-                done
+            # NOTE: cloudflared's image is distroless (no /bin/sh), so a
+            # shell-based retry wrapper is impossible. It isn't needed either:
+            # cloudflared auto-reconnects to the edge on internet loss. The
+            # real cause of restart churn was the liveness probe — see the
+            # tolerant probe settings below.
             image:
               repository: docker.io/cloudflare/cloudflared
               tag: 2026.6.1
@@ -45,6 +39,10 @@ spec:
               TUNNEL_ORIGIN_ENABLE_HTTP2: true
               TUNNEL_TRANSPORT_PROTOCOL: quic
               TUNNEL_POST_QUANTUM: true
+              # Number of edge connection retries before cloudflared gives up
+              # on a given attempt (it keeps retrying regardless). Raising it
+              # makes reconnection more persistent during longer outages.
+              TUNNEL_RETRIES: 10
               TUNNEL_ID:
                 valueFrom:
                   secretKeyRef:
@@ -57,18 +55,34 @@ spec:
               - run
               - "$(TUNNEL_ID)"
             probes:
-              liveness: &probes
+              # cloudflared auto-reconnects to the Cloudflare edge on its own
+              # (with backoff) when the internet drops, so a brief outage must
+              # NOT restart the pod. Keep liveness very tolerant (~5 min) so
+              # only a genuinely hung process gets restarted, while readiness
+              # stays responsive to pull the pod from Service endpoints while
+              # the tunnel is disconnected.
+              liveness:
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
                     path: /ready
                     port: &port 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 10
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ready
+                    port: *port
                   initialDelaySeconds: 0
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  timeoutSeconds: 2
                   failureThreshold: 3
-              readiness: *probes
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
The retry wrapper added a command: [/bin/sh, -c, ...] to the cloudflared
container, but the cloudflare/cloudflared image is distroless and has no
/bin/sh. Every rollout crash-looped with exit 128 (OCI: stat /bin/sh: no
such file or directory), which timed out the Helm upgrade and left the
HelmRelease Stalled/RetriesExceeded.

The wrapper was also the wrong fix: cloudflared auto-reconnects to the
edge on internet loss and does not exit. The actual restart churn came
from the liveness probe killing the pod after ~30s of lost connectivity.

- Remove the /bin/sh retry wrapper (impossible + unnecessary)
- Make liveness tolerant (~5m) so brief WAN/DNS blips don't restart the pod
- Keep readiness responsive to drain the pod from Service endpoints
- Add TUNNEL_RETRIES=10 for more persistent edge reconnection