### PR TITLE
migrate observability from Grafana Cloud to self-hosted VM

### DIFF
--- a/kubernetes/apps/observability/grafana-cloud/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana-cloud/app/externalsecret.yaml
@@ -13,13 +13,11 @@ spec:
     template:
       engineVersion: v2
       data:
-        GRAFANA_CLOUD_PROMETHEUS_URL: '{{ .GRAFANA_CLOUD_PROMETHEUS_URL }}'
-        GRAFANA_CLOUD_PROMETHEUS_USER: '{{ .GRAFANA_CLOUD_PROMETHEUS_USER }}'
-        GRAFANA_CLOUD_LOKI_URL: '{{ .GRAFANA_CLOUD_LOKI_URL }}'
-        GRAFANA_CLOUD_LOKI_USER: '{{ .GRAFANA_CLOUD_LOKI_USER }}'
-        GRAFANA_CLOUD_API_TOKEN: '{{ .GRAFANA_CLOUD_API_TOKEN }}'
-        GRAFANA_CLOUD_GRAFANA_TOKEN: '{{ .GRAFANA_CLOUD_GRAFANA_TOKEN }}'
-        KROMGO_PROMETHEUS_URL: 'https://{{ .GRAFANA_CLOUD_PROMETHEUS_USER }}:{{ .GRAFANA_CLOUD_API_TOKEN }}@{{ trimPrefix "https://" (trimSuffix "/push" .GRAFANA_CLOUD_PROMETHEUS_URL) }}'
+        PROMETHEUS_URL: "http://metrics.internal"
+        LOKI_URL: "http://logs.internal"
+        GRAFANA_URL: "http://grafana.internal"
+        GRAFANA_API_TOKEN: "{{ .GRAFANA_API_TOKEN }}"
+        KROMGO_PROMETHEUS_URL: "http://metrics.internal"
   dataFrom:
     - extract:
-        key: grafana-cloud
+        key: observability-vm

--- a/kubernetes/apps/observability/grafana-cloud/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana-cloud/app/helmrelease.yaml
@@ -34,12 +34,12 @@ spec:
           // Discover ServiceMonitors and scrape metrics
           prometheus.operator.servicemonitors "default" {
             namespaces = []
-            forward_to = [prometheus.relabel.trim_metrics.receiver]
+            forward_to = [prometheus.remote_write.vm.receiver]
           }
 
           prometheus.operator.podmonitors "default" {
             namespaces = []
-            forward_to = [prometheus.relabel.trim_metrics.receiver]
+            forward_to = [prometheus.remote_write.vm.receiver]
           }
 
           // Blackbox probe targets for NFS health (replaces orphaned VMProbes)
@@ -59,7 +59,7 @@ spec:
             targets      = discovery.relabel.blackbox_nfs.output
             job_name     = "blackbox-nfs"
             metrics_path = "/probe"
-            forward_to   = [prometheus.relabel.trim_metrics.receiver]
+            forward_to   = [prometheus.remote_write.vm.receiver]
           }
 
           // Blackbox probe targets for ICMP health (nas, db)
@@ -86,51 +86,13 @@ spec:
             targets      = discovery.relabel.blackbox_devices.output
             job_name     = "blackbox-icmp"
             metrics_path = "/probe"
-            forward_to   = [prometheus.relabel.trim_metrics.receiver]
+            forward_to   = [prometheus.remote_write.vm.receiver]
           }
 
-          // Drop high-cardinality metrics to fit Grafana Cloud free tier (<10K series)
-          // Budget: ~6K of 10K used — comfortable headroom for control-plane, cilium, and cAdvisor
-          prometheus.relabel "trim_metrics" {
-            // Rule 1: Drop high-cardinality noise; keep useful infra (apiserver, cilium, container, controller, etc.)
-            rule {
-              action        = "drop"
-              source_labels = ["__name__"]
-              regex         = "envoy_.*|grafana_.*|go_.*|process_.*|libp2p_.*|quic_.*|vm_.*|vl_.*|vlagent_.*|http_.*|metrics_.*|scrape_.*|promhttp_.*|prometheus_.*|snapshot_.*|field_.*"
-            }
-
-            // Rule 2: Drop noisy ceph internals; keep dashboard-essential groups (pg, mon, mgr, health, osd — not ops)
-            rule {
-              action        = "drop"
-              source_labels = ["__name__"]
-              regex         = "ceph_mds_.*|ceph_bluestore_.*|ceph_bluefs_.*|ceph_paxos_.*|ceph_rocksdb_.*|ceph_prioritycache.*|ceph_purge_.*|ceph_blk_.*|ceph_objecter_.*|ceph_AsyncMessenger_.*|ceph_num_.*|ceph_prometheus_.*|ceph_healthcheck_.*|ceph_exporter_.*|ceph_disk_.*|ceph_osd_op_.*"
-            }
-
-            // Rule 3: Drop high-cardinality or noisy kube metrics, keep useful small groups
-            rule {
-              action        = "drop"
-              source_labels = ["__name__"]
-              regex         = "kube_pod_annotations|kube_pod_labels|kube_mutatingwebhookconfiguration_.*|kube_validatingwebhookconfiguration_.*|kube_networkpolicy_.*|kube_lease_.*|kube_resourcequota_.*|kube_storageclass_.*|kube_job_.*|kube_cronjob_.*|kube_replicaset_.*"
-            }
-
-            // Rule 4: Drop noisy node kernel internals, keep essential hardware/OS metrics
-            rule {
-              action        = "drop"
-              source_labels = ["__name__"]
-              regex         = "node_xfs_.*|node_netstat_.*|node_vmstat_.*|node_sockstat_.*|node_timex_.*|node_hwmon_.*|node_nf_.*|node_softnet_.*|node_schedstat_.*|node_selinux_.*|node_bonding_.*|node_cooling_.*|node_watchdog_.*|node_ipvs_.*|node_thermal_.*|node_udp_.*|node_textfile_.*|node_arp_.*|node_dmi_.*|node_forks_.*|node_intr_.*|node_nvme_.*|node_context_.*|node_exporter_.*|node_filefd_.*|node_procs_.*|node_scrape_.*|node_entropy_.*|node_pressure_.*"
-            }
-
-            forward_to = [prometheus.remote_write.cloud.receiver]
-          }
-
-          // Remote write to Grafana Cloud Prometheus
-          prometheus.remote_write "cloud" {
+          // Remote write to self-hosted Prometheus on VM (no auth, IP-allowlisted)
+          prometheus.remote_write "vm" {
             endpoint {
-              url = env("GRAFANA_CLOUD_PROMETHEUS_URL")
-              basic_auth {
-                username = env("GRAFANA_CLOUD_PROMETHEUS_USER")
-                password = env("GRAFANA_CLOUD_API_TOKEN")
-              }
+              url = env("PROMETHEUS_URL") + "/api/v1/write"
             }
           }
 
@@ -175,16 +137,12 @@ spec:
                 container = "container",
               }
             }
-            forward_to = [loki.write.cloud.receiver]
+            forward_to = [loki.write.vm.receiver]
           }
 
-          // Send logs to Grafana Cloud Loki
-          loki.write "cloud" {
+          // Send logs to self-hosted Loki on VM (no auth, IP-allowlisted)
+          loki.write "vm" {
             endpoint {
-              url = env("GRAFANA_CLOUD_LOKI_URL") + "/loki/api/v1/push"
-              basic_auth {
-                username = env("GRAFANA_CLOUD_LOKI_USER")
-                password = env("GRAFANA_CLOUD_API_TOKEN")
-              }
+              url = env("LOKI_URL") + "/loki/api/v1/push"
             }
           }

--- a/kubernetes/apps/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafana.yaml
@@ -8,8 +8,8 @@ metadata:
     dashboards: grafana
 spec:
   external:
-    url: https://chippermagpie793.grafana.net
+    url: http://grafana.internal
     tenantNamespace: observability
     apiKey:
       name: grafana-cloud-credentials
-      key: GRAFANA_CLOUD_GRAFANA_TOKEN
+      key: GRAFANA_API_TOKEN

--- a/kubernetes/apps/observability/grafana/instance/grafanadashboards.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadashboards.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   # renovate: depName="Prometheus Blackbox Exporter"
   url: https://grafana.com/api/dashboards/7587/revisions/3/download
@@ -26,7 +26,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   # renovate: depName="Cert-manager-Kubernetes"
   url: https://grafana.com/api/dashboards/20842/revisions/3/download
@@ -42,7 +42,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   # renovate: depName="Cloudflare Tunnels (cloudflared)"
   url: https://grafana.com/api/dashboards/17457/revisions/6/download
@@ -58,7 +58,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   # renovate: depName="External-dns"
   url: https://grafana.com/api/dashboards/15038/revisions/3/download
@@ -74,7 +74,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/external-secrets/external-secrets/main/docs/snippets/dashboard.json
 ---
@@ -89,7 +89,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/TwiN/gatus/master/.examples/docker-compose-grafana-prometheus/grafana/provisioning/dashboards/gatus.json
 ---
@@ -104,7 +104,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   # renovate: depName="Node Exporter Full"
   url: https://grafana.com/api/dashboards/1860/revisions/45/download
@@ -120,7 +120,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/examples/grafana-dashboard.json
 ---
@@ -135,7 +135,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   # renovate: depName="Spegel"
   url: https://grafana.com/api/dashboards/18089/revisions/1/download
@@ -151,7 +151,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   # renovate: depName="Unpackerr"
   url: https://grafana.com/api/dashboards/18817/revisions/1/download
@@ -167,7 +167,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   # renovate: depName="VolSync Dashboard"
   url: https://grafana.com/api/dashboards/21356/revisions/3/download
@@ -183,7 +183,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/2842/revisions/17/download
 ---
@@ -198,7 +198,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/5336/revisions/9/download
 ---
@@ -213,7 +213,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/5342/revisions/9/download
 ---
@@ -228,7 +228,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/refs/heads/main/monitoring/configs/dashboards/cluster.json
 ---
@@ -243,7 +243,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/refs/heads/main/monitoring/configs/dashboards/control-plane.json
 ---
@@ -258,7 +258,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/controlplaneio-fluxcd/flux-operator/refs/heads/main/config/monitoring/dashboards/flux-k8s-api-performance.json
 ---
@@ -273,7 +273,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/controlplaneio-fluxcd/flux-operator/refs/heads/main/config/monitoring/dashboards/flux-performance.json
 ---
@@ -288,7 +288,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/kedacore/keda/main/config/grafana/kubescaler.json
 ---
@@ -303,7 +303,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/cilium/cilium/main/examples/kubernetes/addons/prometheus/monitoring-example/dashboards/cilium.json
 ---
@@ -318,7 +318,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   # renovate: depName="Kubernetes / Views / Global"
   url: https://grafana.com/api/dashboards/15757/revisions/43/download
@@ -334,7 +334,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasources:
-    - datasourceName: GrafanaCloud
+    - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   # renovate: depName="etcd"
   url: https://grafana.com/api/dashboards/15055/revisions/9/download

--- a/kubernetes/apps/observability/grafana/instance/grafanadatasource-loki.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadatasource-loki.yaml
@@ -3,7 +3,7 @@
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 metadata:
-  name: grafanacloud-prometheus
+  name: loki
   labels:
     dashboards: grafana
 spec:
@@ -12,8 +12,7 @@ spec:
     matchLabels:
       dashboards: grafana
   datasource:
-    name: Prometheus
-    type: prometheus
+    name: Loki
+    type: loki
     access: proxy
-    url: http://metrics.internal
-    isDefault: true
+    url: http://logs.internal

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/externalsecret.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
     template:
       engineVersion: v2
       data:
-        PROMETHEUS_ENDPOINT: 'https://{{ .GRAFANA_CLOUD_PROMETHEUS_USER }}:{{ .GRAFANA_CLOUD_API_TOKEN }}@{{ trimPrefix "https://" (trimSuffix "/push" .GRAFANA_CLOUD_PROMETHEUS_URL) }}'
+        PROMETHEUS_ENDPOINT: "http://metrics.internal"
   dataFrom:
     - extract:
-        key: grafana-cloud
+        key: observability-vm

--- a/kubernetes/components/keda/nfs-scaler/kustomization.yaml
+++ b/kubernetes/components/keda/nfs-scaler/kustomization.yaml
@@ -4,4 +4,3 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
   - ./scaledobject.yaml
-  - ./triggerauthentication.yaml

--- a/kubernetes/components/keda/nfs-scaler/scaledobject.yaml
+++ b/kubernetes/components/keda/nfs-scaler/scaledobject.yaml
@@ -17,11 +17,7 @@ spec:
   triggers:
     - type: prometheus
       metadata:
-        serverAddress: https://prometheus-prod-65-prod-eu-west-2.grafana.net/api/prom
-        authModes: basic
+        serverAddress: http://metrics.internal
         query: probe_success{instance=~".+:2049"}
         threshold: "1"
-        ignoreNullValues: "0"
-      authenticationRef:
-        kind: ClusterTriggerAuthentication
-        name: keda-prometheus-credentials
+        ignoreNullValues: "1"

--- a/vm/observability/.env.example
+++ b/vm/observability/.env.example
@@ -1,0 +1,3 @@
+# Grafana admin credentials
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=CHANGE_ME

--- a/vm/observability/caddy/Caddyfile
+++ b/vm/observability/caddy/Caddyfile
@@ -1,0 +1,31 @@
+# Caddy reverse proxy for observability stack
+# IP-allowlisted to home LAN
+
+:80 {
+    @allowed {
+        remote_ip 192.168.69.0/24 192.168.88.0/24
+    }
+
+    # Serve content for allowed IPs
+    handle @allowed {
+        @metrics host metrics.internal
+        handle @metrics {
+            reverse_proxy prometheus:9090
+        }
+
+        @logs host logs.internal
+        handle @logs {
+            reverse_proxy loki:3100
+        }
+
+        @grafana host grafana.internal
+        handle @grafana {
+            reverse_proxy grafana:3000
+        }
+    }
+
+    # Block everything else
+    handle {
+        abort
+    }
+}

--- a/vm/observability/deploy.sh
+++ b/vm/observability/deploy.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Deploy observability stack to the VM
+# Usage: ./deploy.sh [--dry-run]
+set -euo pipefail
+
+VM_IP="192.168.3.3"
+VM_USER="akira"
+REMOTE_DIR="/opt/observability"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+log() { printf "\033[0;32m==> %s\033[0m\n" "$*"; }
+err() { printf "\033[0;31m==> ERROR: %s\033[0m\n" "$*" >&2; exit 1; }
+
+# Check VM connectivity
+log "Checking VM connectivity..."
+ssh -o ConnectTimeout=5 "${VM_USER}@${VM_IP}" "echo ok" >/dev/null 2>&1 \
+  || err "Cannot reach VM at ${VM_IP}. Is it up?"
+
+# Check Docker
+log "Checking Docker..."
+ssh "${VM_USER}@${VM_IP}" "docker --version && docker compose version" 2>/dev/null \
+  || err "Docker not installed on VM"
+
+# Create remote directory
+log "Creating remote directory ${REMOTE_DIR}..."
+ssh "${VM_USER}@${VM_IP}" "sudo mkdir -p ${REMOTE_DIR} && sudo chown ${VM_USER}:${VM_USER} ${REMOTE_DIR}"
+
+# Sync files
+log "Syncing config files..."
+rsync -avz --delete \
+  "${SCRIPT_DIR}/docker-compose.yaml" \
+  "${SCRIPT_DIR}/.env.example" \
+  "${SCRIPT_DIR}/prometheus/" \
+  "${SCRIPT_DIR}/loki/" \
+  "${SCRIPT_DIR}/grafana/" \
+  "${SCRIPT_DIR}/caddy/" \
+  "${VM_USER}@${VM_IP}:${REMOTE_DIR}/"
+
+# Copy .env if it doesn't exist
+ssh "${VM_USER}@${VM_IP}" "test -f ${REMOTE_DIR}/.env || cp ${REMOTE_DIR}/.env.example ${REMOTE_DIR}/.env"
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+  log "Dry run complete. Files synced to ${VM_IP}:${REMOTE_DIR}"
+  log "Edit .env on the VM, then run: ssh ${VM_USER}@${VM_IP} 'cd ${REMOTE_DIR} && docker compose up -d'"
+  exit 0
+fi
+
+# Start services
+log "Starting services..."
+ssh "${VM_USER}@${VM_IP}" "cd ${REMOTE_DIR} && docker compose up -d"
+
+# Wait for health
+log "Waiting for services to start..."
+sleep 10
+
+# Verify
+log "Verifying services..."
+for svc in prometheus loki grafana caddy; do
+  status=$(ssh "${VM_USER}@${VM_IP}" "docker inspect --format='{{.State.Status}}' ${svc}" 2>/dev/null)
+  if [[ "$status" == "running" ]]; then
+    log "  ${svc}: running"
+  else
+    err "  ${svc}: ${status}"
+  fi
+done
+
+log "Deploy complete!"
+log ""
+log "Services available at:"
+log "  Prometheus: http://metrics.internal"
+log "  Loki:       http://logs.internal"
+log "  Grafana:    http://grafana.internal"
+log ""
+log "Next steps:"
+log "  1. Add DNS records to UniFi router:"
+log "     - metrics.internal → ${VM_IP}"
+log "     - logs.internal    → ${VM_IP}"
+log "     - grafana.internal → ${VM_IP}"
+log "  2. Verify from cluster: kubectl run curl-test --rm -it --image=curlimages/curl -- curl http://metrics.internal/-/healthy"

--- a/vm/observability/docker-compose.yaml
+++ b/vm/observability/docker-compose.yaml
@@ -1,0 +1,91 @@
+---
+# Self-hosted observability stack: Prometheus + Loki + Grafana + Caddy
+# Replaces Grafana Cloud free tier for the home-ops Kubernetes cluster.
+#
+# Usage:
+#   cp .env.example .env   # fill in credentials
+#   docker compose up -d
+#
+# Services exposed via Caddy (IP-allowlisted to cluster nodes):
+#   - metrics.internal  → Prometheus
+#   - logs.internal     → Loki
+#   - grafana.internal  → Grafana
+
+services:
+  prometheus:
+    image: prom/prometheus:v3.4.2
+    container_name: prometheus
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=14d
+      - --storage.tsdb.retention.size=10GB
+      - --web.enable-remote-write-receiver
+      - --web.enable-lifecycle
+      - --web.enable-admin-api
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    networks:
+      - observability
+    expose:
+      - "9090"
+
+  loki:
+    image: grafana/loki:3.4.2
+    container_name: loki
+    restart: unless-stopped
+    command: -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki-data:/loki
+    networks:
+      - observability
+    expose:
+      - "3100"
+
+  grafana:
+    image: grafana/grafana:11.6.0
+    container_name: grafana
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+      GF_SERVER_ROOT_URL: "http://grafana.internal"
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-data:/var/lib/grafana
+    networks:
+      - observability
+    expose:
+      - "3000"
+
+  caddy:
+    image: caddy:2.10.0
+    container_name: caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+    networks:
+      - observability
+    depends_on:
+      - prometheus
+      - loki
+      - grafana
+
+volumes:
+  prometheus-data:
+  loki-data:
+  grafana-data:
+  caddy-data:
+
+networks:
+  observability:
+    driver: bridge

--- a/vm/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/vm/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: 1
+
+providers:
+  - name: default
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 60
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: true

--- a/vm/observability/grafana/provisioning/datasources/datasources.yml
+++ b/vm/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false

--- a/vm/observability/loki/loki-config.yml
+++ b/vm/observability/loki/loki-config.yml
@@ -1,0 +1,47 @@
+---
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+limits_config:
+  retention_period: 14d
+  max_query_length: 14d
+  max_query_parallelism: 4
+  max_entries_limit_per_query: 5000
+  ingestion_rate_mb: 16
+  ingestion_burst_size_mb: 32
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  delete_request_store: filesystem
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+analytics:
+  reporting_enabled: false

--- a/vm/observability/prometheus/prometheus.yml
+++ b/vm/observability/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+---
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+# Receive metrics via remote_write from Alloy in the cluster
+remote_write: []
+
+# No local scrape targets — all metrics arrive via remote_write from Alloy
+scrape_configs: []


### PR DESCRIPTION
Replace Grafana Cloud free tier (15K series limit, 429 errors) with self-hosted Prometheus + Loki + Grafana on external VM

VM stack (vm/observability/):
- Prometheus 3.4.2 with remote_write_receiver, 14d retention
- Loki 3.4.2 with filesystem storage, 14d retention
- Grafana 11.6.0 with auto-provisioned datasources
- Caddy reverse proxy with LAN IP allowlist

Cluster changes:
- Alloy: remove all trim_metrics relabel rules (no more series limits), remote_write to http://metrics.internal, Loki push to http://logs.internal
- KEDA nfs-scaler: query http://metrics.internal, ignoreNullValues=1 (fallback when VM down), remove auth
- grafana-operator: external Grafana at http://grafana.internal
- GrafanaDatasource: Prometheus + Loki on VM (no auth)
- All dashboards: GrafanaCloud -> Prometheus datasource rename
- ExternalSecrets: new observability-vm 1Password item
- Rook-Ceph: PROMETHEUS_ENDPOINT -> http://metrics.internal

## What's Changed
<!-- Brief description of what you're adding/changing -->

### Type of Change

- [x] 🆕 New app/service
- [ ] ⬆️ Version upgrade
- [ ] 🔧 Config change
- [ ] 🐛 Bug fix
- [ ] 🧹 Cleanup

### Notes and apps affected
<!-- Which apps or namespaces will this impact? -->
