### PR TITLE
fix(rook-ceph): use mgr-dashboard service instead of hardcoded node IP

### DIFF
--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
       existingSecret: konflate-secret
     httpRoute:
       enabled: true
+      annotations:
+        glance/show: "true"
+        glance/name: Konflate
+        glance/icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/kubernetes.png
+        glance/description: "Pull request review and validation."
       parentRefs:
         - name: external
           namespace: kube-system

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/dashboard-proxy.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/dashboard-proxy.yaml
@@ -1,7 +1,7 @@
 ---
 # Cilium Gateway envoy can't EDS-proxy to hostNetwork pods (rook-ceph-mgr).
 # This proxy uses regular pod networking so the envoy can reach it, then
-# forwards to the mgr dashboard at its host IP.
+# forwards to the mgr dashboard via the mgr-dashboard service.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,7 +53,7 @@ data:
     server {
         listen 7000;
         location / {
-            proxy_pass http://192.168.69.112:7000;
+            proxy_pass http://rook-ceph-mgr-dashboard:7000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }


### PR DESCRIPTION
The nginx dashboard proxy was hardcoded to 192.168.69.112:7000,
but the mgr pod runs on node k8s-1 (192.168.69.111). Using the
ClusterIP service rook-ceph-mgr-dashboard ensures the proxy always
reaches the active mgr regardless of which node it's on.