### PR TITLE
feat(container)!: Update image quay.io/ceph/ceph (v19.2.5 → v20.2.2)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
           memory: 64Mi
     cephImage:
       repository: quay.io/ceph/ceph
-      tag: v19.2.5
+      tag: v20.2.2
     operatorNamespace: rook-ceph
     # Route is managed by a separate HTTPRoute (dashboard-proxy) instead of the
     # Helm chart, because Cilium Gateway envoy can't EDS-proxy to hostNetwork pods.


### PR DESCRIPTION
Major Ceph Squid → Tentacle upgrade (v19 → v20).

Follows the official Rook Ceph upgrade guide:
https://rook.github.io/docs/rook/v1.20/Upgrade/ceph-upgrade/

- Rook operator already at v1.20.2 (compatible)
- v20.2.2 avoids the known data corruption bug in v20.2.0 with read affinity
- CephCluster.spec.cephVersion.image, toolbox, and cephImage.tag all bumped
- Cluster is HEALTH_OK and PGs active+clean