### PR TITLE
fix(system-upgrade): split CRs into dependent Kustomization to avoid dry-run failure

### DIFF
--- a/kubernetes/apps/system-upgrade/cr/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/cr/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./repository.yaml
-  - ./helmrelease.yaml
-  - ./externalsecret.yaml
+  - ../app/talos-upgrade.yaml
+  - ../app/kubernetes-upgrade.yaml

--- a/kubernetes/apps/system-upgrade/ks.yaml
+++ b/kubernetes/apps/system-upgrade/ks.yaml
@@ -21,3 +21,26 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tuppr-cr
+  namespace: system-upgrade
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: tuppr-cr
+  dependsOn:
+    - name: tuppr
+      namespace: system-upgrade
+  path: ./kubernetes/apps/system-upgrade/cr
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: system-upgrade
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
The TalosUpgrade/KubernetesUpgrade CRs need CRDs from the tuppr HelmRelease. Same Kustomization batch causes dry-run failure. Splitting into two Flux Kustomizations with `dependsOn: tuppr -> tuppr-cr`.

Follows the rook-ceph multi-Kustomization pattern in `ks.yaml`.