### PR TITLE
fix(system-upgrade): remove commonMetadata labels conflicting with tuppr chart

### DIFF
--- a/kubernetes/apps/system-upgrade/ks.yaml
+++ b/kubernetes/apps/system-upgrade/ks.yaml
@@ -5,9 +5,6 @@ metadata:
   name: &app tuppr
   namespace: &namespace system-upgrade
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets-stores
       namespace: kube-system
@@ -28,9 +25,6 @@ metadata:
   name: tuppr-cr
   namespace: system-upgrade
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: tuppr-cr
   dependsOn:
     - name: tuppr
       namespace: system-upgrade


### PR DESCRIPTION
Flux Kustomization `commonMetadata.labels` propagates into rendered Helm resources via post-render. The tuppr chart already defines `app.kubernetes.io/name`, causing YAML duplicate-key errors on install.