### PR TITLE
fix(system-upgrade): remove duplicate labels from tuppr values

### DIFF
--- a/kubernetes/apps/system-upgrade/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/app/helmrelease.yaml
@@ -33,12 +33,8 @@ spec:
     monitoring:
       serviceMonitor:
         enabled: true
-        labels:
-          app.kubernetes.io/name: tuppr
       prometheusRule:
         enabled: true
-        labels:
-          app.kubernetes.io/name: tuppr
       dashboards:
         enabled: true
         labels:


### PR DESCRIPTION
The tuppr chart already defines `app.kubernetes.io/name` via its standard `_helpers.tpl` labels. Specifying them again in `monitoring.serviceMonitor.labels` and `monitoring.prometheusRule.labels` causes YAML duplicate-key errors during Helm install.