### PR TITLE
fix(system-upgrade): remove duplicate port 8081 from tuppr values

### DIFF
--- a/kubernetes/apps/system-upgrade/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/app/helmrelease.yaml
@@ -23,7 +23,6 @@ spec:
         enabled: true
       metrics:
         enabled: true
-        port: 8081
     webhook:
       enabled: true
     notification:


### PR DESCRIPTION
The tuppr chart defaults to metrics port 8081. Specifying it again duplicates the port entry on the manager container.