### PR TITLE
fix(system-upgrade): disable tuppr pushover notification until token exists

### DIFF
--- a/kubernetes/apps/system-upgrade/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/app/helmrelease.yaml
@@ -26,9 +26,7 @@ spec:
     webhook:
       enabled: true
     notification:
-      enabled: true
-      secretName: tuppr-notification
-      secretKey: url
+      enabled: false
     monitoring:
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/system-upgrade/app/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/app/kustomization.yaml
@@ -4,4 +4,3 @@ kind: Kustomization
 resources:
   - ./repository.yaml
   - ./helmrelease.yaml
-  - ./externalsecret.yaml


### PR DESCRIPTION
The 1Password `pushover` item is missing the `GATUS_PUSHOVER_TOKEN` field needed for Pushover notifications. Without it, the ExternalSecret fails and the tuppr pod can't start (blocking on `tuppr-notification` secret). Disabling notification for now; re-enable when the token is added to 1Password.