### PR TITLE
fix(system-upgrade): increase tuppr memory limit

### DIFF
--- a/kubernetes/apps/system-upgrade/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/app/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
             dashboards: grafana
     resources:
       requests:
-        cpu: 10m
-        memory: 64Mi
-      limits:
+        cpu: 50m
         memory: 128Mi
+      limits:
+        memory: 256Mi


### PR DESCRIPTION
tuppr controller OOMKilled at 128Mi. Raised to 256Mi.