### PR TITLE
reloader: auto-restart grafana nginx on ConfigMap change

### DIFF
--- a/kubernetes/apps/external/grafana/app/nginx-proxy.yaml
+++ b/kubernetes/apps/external/grafana/app/nginx-proxy.yaml
@@ -45,6 +45,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: grafana-nginx
+      annotations:
+        reloader.stakater.com/auto: "true"
     spec:
       containers:
         - name: nginx


### PR DESCRIPTION
Adds `reloader.stakater.com/auto: "true"` annotation to the grafana-nginx Deployment pod template so ConfigMap changes trigger automatic pod restarts. Fixes the issue where Flux updates the ConfigMap but nginx keeps serving the old config until a manual rollout.