### PR TITLE
fix(tuppr): set maintenance window to 23:15 Paris for tonight's test

### DIFF
--- a/kubernetes/apps/system-upgrade/app/kubernetes-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/app/kubernetes-upgrade.yaml
@@ -9,7 +9,7 @@ spec:
     version: v1.35.0
   maintenance:
     windows:
-      - start: "0 2 * * 0"
+      - start: "15 23 * * *"
         duration: "4h"
         timezone: "Europe/Paris"
   healthChecks:

--- a/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
@@ -17,7 +17,7 @@ spec:
   parallelism: 1
   maintenance:
     windows:
-      - start: "0 2 * * 0"
+      - start: "15 23 * * *"
         duration: "4h"
         timezone: "Europe/Paris"
   healthChecks:


### PR DESCRIPTION
Temporarily change maintenance window to daily at 23:15 Paris time to test the Talos + Kubernetes upgrade tonight. Revert to Sunday 02:00 after testing.