### PR TITLE
fix: remove stale inline schema from 1password ClusterSecretStore

### DIFF
--- a/kubernetes/apps/kube-system/external-secrets/stores/onepassword/clustersecretstore.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/onepassword/clustersecretstore.yaml
@@ -1,5 +1,4 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/axeII/crds/main/clustersecretstore_v1beta1.json
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:


### PR DESCRIPTION
The inline schema reference at axeII/crds doesn't include onepasswordSDK provider. yayamlls validates against the live CRD which does include it.