### PR TITLE
fix(tuppr): restore Sunday maintenance window, remove broken ceph hooks

### DIFF
--- a/kubernetes/apps/system-upgrade/app/kubernetes-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/app/kubernetes-upgrade.yaml
@@ -9,7 +9,7 @@ spec:
     version: v1.35.0
   maintenance:
     windows:
-      - start: "15 23 * * *"
+      - start: "0 2 * * 0"
         duration: "4h"
         timezone: "Europe/Paris"
   healthChecks:

--- a/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
@@ -17,7 +17,7 @@ spec:
   parallelism: 1
   maintenance:
     windows:
-      - start: "15 23 * * *"
+      - start: "0 2 * * 0"
         duration: "4h"
         timezone: "Europe/Paris"
   healthChecks:
@@ -29,56 +29,3 @@ spec:
       name: rook-ceph
       namespace: rook-ceph
       expr: status.ceph.health in ["HEALTH_OK"]
-  hooks:
-    pre:
-      - name: ceph-set-noout
-        image: docker.io/rook/ceph:v1.20.2
-        command:
-          - sh
-          - -c
-        args:
-          - >-
-            printf '[global]\n\tmon_host = %s\n' "$(cat /etc/ceph/mon_host)"
-            > /tmp/ceph.conf &&
-            printf '[client.admin]\n\tkey = %s\n' "$CEPH_SECRET" > /tmp/keyring
-            &&
-            ceph -c /tmp/ceph.conf --keyring /tmp/keyring osd set noout
-        env:
-          - name: CEPH_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: rook-ceph-mon
-                key: ceph-secret
-        volumeMounts:
-          - name: ceph-config
-            mountPath: /etc/ceph
-        volumes:
-          - name: ceph-config
-            secret:
-              secretName: rook-ceph-config
-    post:
-      - name: ceph-unset-noout
-        image: docker.io/rook/ceph:v1.20.2
-        command:
-          - sh
-          - -c
-        args:
-          - >-
-            printf '[global]\n\tmon_host = %s\n' "$(cat /etc/ceph/mon_host)"
-            > /tmp/ceph.conf &&
-            printf '[client.admin]\n\tkey = %s\n' "$CEPH_SECRET" > /tmp/keyring
-            &&
-            ceph -c /tmp/ceph.conf --keyring /tmp/keyring osd unset noout
-        env:
-          - name: CEPH_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: rook-ceph-mon
-                key: ceph-secret
-        volumeMounts:
-          - name: ceph-config
-            mountPath: /etc/ceph
-        volumes:
-          - name: ceph-config
-            secret:
-              secretName: rook-ceph-config


### PR DESCRIPTION
Restore maintenance window to Sunday 02:00 Paris time (original schedule after testing). Remove ceph hooks that don't work cross-namespace (secrets are in rook-ceph ns, hooks run in system-upgrade ns). Ceph noout is still manually configurable.