### PR TITLE
fix(tuppr): add ExternalSecrets for rook-ceph secrets, re-enable ceph hooks

### DIFF
--- a/kubernetes/apps/kube-system/external-secrets/stores/kubernetes/clustersecretstore.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/kubernetes/clustersecretstore.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: rook-ceph
+      auth:
+        serviceAccount:
+          name: external-secrets
+          namespace: kube-system

--- a/kubernetes/apps/kube-system/external-secrets/stores/kubernetes/kustomization.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/kubernetes/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./repository.yaml
-  - ./helmrelease.yaml
-  - ./ceph-secrets.yaml
+  - ./clustersecretstore.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/kube-system/external-secrets/stores/kubernetes/rbac.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/kubernetes/rbac.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-rook-ceph-reader
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - rook-ceph-mon
+      - rook-ceph-config
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-secrets-rook-ceph-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-rook-ceph-reader
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: kube-system

--- a/kubernetes/apps/kube-system/external-secrets/stores/kustomization.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 namespace: kube-system
 resources:
   - ./onepassword
+  - ./kubernetes

--- a/kubernetes/apps/system-upgrade/app/ceph-secrets.yaml
+++ b/kubernetes/apps/system-upgrade/app/ceph-secrets.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rook-ceph-mon
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes
+  target:
+    name: rook-ceph-mon
+    creationPolicy: Owner
+  data:
+    - secretKey: ceph-secret
+      remoteRef:
+        key: rook-ceph-mon
+        property: ceph-secret
+    - secretKey: ceph-username
+      remoteRef:
+        key: rook-ceph-mon
+        property: ceph-username
+    - secretKey: fsid
+      remoteRef:
+        key: rook-ceph-mon
+        property: fsid
+    - secretKey: mon-secret
+      remoteRef:
+        key: rook-ceph-mon
+        property: mon-secret
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rook-ceph-config
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes
+  target:
+    name: rook-ceph-config
+    creationPolicy: Owner
+  data:
+    - secretKey: mon_host
+      remoteRef:
+        key: rook-ceph-config
+        property: mon_host
+    - secretKey: mon_initial_members
+      remoteRef:
+        key: rook-ceph-config
+        property: mon_initial_members

--- a/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
@@ -29,3 +29,56 @@ spec:
       name: rook-ceph
       namespace: rook-ceph
       expr: status.ceph.health in ["HEALTH_OK"]
+  hooks:
+    pre:
+      - name: ceph-set-noout
+        image: docker.io/rook/ceph:v1.20.2
+        command:
+          - sh
+          - -c
+        args:
+          - >-
+            printf '[global]\n\tmon_host = %s\n' "$(cat /etc/ceph/mon_host)"
+            > /tmp/ceph.conf &&
+            printf '[client.admin]\n\tkey = %s\n' "$CEPH_SECRET" > /tmp/keyring
+            &&
+            ceph -c /tmp/ceph.conf --keyring /tmp/keyring osd set noout
+        env:
+          - name: CEPH_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: rook-ceph-mon
+                key: ceph-secret
+        volumeMounts:
+          - name: ceph-config
+            mountPath: /etc/ceph
+        volumes:
+          - name: ceph-config
+            secret:
+              secretName: rook-ceph-config
+    post:
+      - name: ceph-unset-noout
+        image: docker.io/rook/ceph:v1.20.2
+        command:
+          - sh
+          - -c
+        args:
+          - >-
+            printf '[global]\n\tmon_host = %s\n' "$(cat /etc/ceph/mon_host)"
+            > /tmp/ceph.conf &&
+            printf '[client.admin]\n\tkey = %s\n' "$CEPH_SECRET" > /tmp/keyring
+            &&
+            ceph -c /tmp/ceph.conf --keyring /tmp/keyring osd unset noout
+        env:
+          - name: CEPH_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: rook-ceph-mon
+                key: ceph-secret
+        volumeMounts:
+          - name: ceph-config
+            mountPath: /etc/ceph
+        volumes:
+          - name: ceph-config
+            secret:
+              secretName: rook-ceph-config


### PR DESCRIPTION
Fixes the cross-namespace secret access issue. The tuppr operator creates hook jobs in system-upgrade but the ceph secrets (rook-ceph-mon, rook-ceph-config) are in rook-ceph namespace.\n\nAdds:\n- RBAC for external-secrets SA to read rook-ceph secrets\n- Kubernetes provider ClusterSecretStore pointing to rook-ceph ns\n- ExternalSecrets in system-upgrade to mirror both secrets\n- Re-adds the ceph pre/post hooks (set noout / unset noout)