### PR TITLE
fix(tuppr): fix ClusterSecretStore kubernetes provider

### DIFF
--- a/kubernetes/apps/kube-system/external-secrets/stores/kubernetes/clustersecretstore.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/kubernetes/clustersecretstore.yaml
@@ -2,12 +2,8 @@
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
-  name: kubernetes
+  name: rook-ceph
 spec:
   provider:
     kubernetes:
       remoteNamespace: rook-ceph
-      auth:
-        serviceAccount:
-          name: external-secrets
-          namespace: kube-system

--- a/kubernetes/apps/system-upgrade/app/ceph-secrets.yaml
+++ b/kubernetes/apps/system-upgrade/app/ceph-secrets.yaml
@@ -7,7 +7,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: kubernetes
+    name: rook-ceph
   target:
     name: rook-ceph-mon
     creationPolicy: Owner
@@ -37,7 +37,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: kubernetes
+    name: rook-ceph
   target:
     name: rook-ceph-config
     creationPolicy: Owner


### PR DESCRIPTION
Use default pod SA auth instead of serviceAccount impersonation. Renamed store to rook-ceph for clarity.