### PR TITLE
fix(tuppr): add CA provider to kubernetes ClusterSecretStore

### DIFF
--- a/kubernetes/apps/kube-system/external-secrets/stores/kubernetes/clustersecretstore.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/kubernetes/clustersecretstore.yaml
@@ -7,3 +7,13 @@ spec:
   provider:
     kubernetes:
       remoteNamespace: rook-ceph
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          namespace: kube-system
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: external-secrets
+          namespace: kube-system


### PR DESCRIPTION
Added missing caProvider config so the kubernetes provider can reach the API server.