### PR TITLE
fix(renovate): move kubelet to Talos group, bump K8s to v1.36.2

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -25,20 +25,18 @@
       minimumGroupSize: 2,
     },
     {
-      description: "Kubernetes Group",
-      groupName: "kubernetes",
+      description: "Talos Group",
+      groupName: "talos",
       matchDatasources: ["docker"],
       matchPackageNames: [
-        "/kube-apiserver/",
-        "/kube-controller-manager/",
-        "/kube-proxy/",
-        "/kube-scheduler/",
+        "/installer/",
         "/kubelet/",
+        "/talosctl/",
       ],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
-      minimumGroupSize: 5,
+      minimumGroupSize: 2,
     },
     {
       description: "Cert-Manager Group",
@@ -114,16 +112,7 @@
         commitMessageTopic: "{{{groupName}}} group",
       },
     },
-    {
-      description: "Talos Group",
-      groupName: "talos",
-      matchDatasources: ["docker"],
-      matchPackageNames: ["/installer/", "/talosctl/"],
-      group: {
-        commitMessageTopic: "{{{groupName}}} group",
-      },
-      minimumGroupSize: 2,
-    },
+
     {
       description: "Dragonfly Group",
       groupName: "dragonfly",

--- a/kubernetes/apps/system-upgrade/app/kubernetes-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/app/kubernetes-upgrade.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.35.0
+    version: v1.36.2
   maintenance:
     windows:
       - start: "0 2 * * 0"

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -1,4 +1,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.13.6
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.35.0
+kubernetesVersion: v1.36.2


### PR DESCRIPTION
Fixes: Renovate stuck on kubelet updates because Kubernetes group had minimumGroupSize:5 expecting 4 other images not in our repo. Moved kubelet to Talos group with minimumGroupSize:2 so installer + kubelet update together.\n\nAlso: bump K8s to v1.36.2 (Talos v1.13.6 ships kubelet:v1.36.2).