### PR TITLE
fix(karakeep): add chrome memory request, keep required affinity

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -80,6 +80,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 256Mi
               limits:
                 memory: 3Gi
 
@@ -89,16 +90,14 @@ spec:
         pod:
           affinity:
             podAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - weight: 100
-                  podAffinityTerm:
-                    labelSelector:
-                      matchExpressions:
-                        - key: app.kubernetes.io/name
-                          operator: In
-                          values:
-                            - *app
-                    topologyKey: kubernetes.io/hostname
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: app.kubernetes.io/name
+                        operator: In
+                        values:
+                          - *app
+                  topologyKey: kubernetes.io/hostname
         containers:
           app:
             image:


### PR DESCRIPTION
Meilisearch shares a PVC with karakeep (RWO) so it must run on the same node.\n\n- Reverted affinity back to required (meilisearch must co-locate with karakeep main app)\n- Added explicit memory request (256Mi) to chrome container (was defaulting to 3Gi from limit)\n- This frees ~2.75Gi request capacity on k8s-2, enough for meilisearch's 512Mi request