### PR TITLE
fix(karakeep): use controller label for podAffinity to avoid matching chrome

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -93,10 +93,10 @@ spec:
               requiredDuringSchedulingIgnoredDuringExecution:
                 - labelSelector:
                     matchExpressions:
-                      - key: app.kubernetes.io/name
+                      - key: app.kubernetes.io/controller
                         operator: In
                         values:
-                          - *app
+                          - karakeep
                   topologyKey: kubernetes.io/hostname
         containers:
           app:


### PR DESCRIPTION
Meilisearch was following chrome pods (same app.kubernetes.io/name label) to other nodes, but its PVC is on k8s-2 with the main karakeep app.\n\nChanged the label selector from app.kubernetes.io/name=karakeep to app.kubernetes.io/controller=karakeep so meilisearch only co-locates with the main karakeep pod, not chrome.