### PR TITLE
fix(alloy): add memory request+limit, fix out-of-order samples in VM Prom

### DIFF
--- a/kubernetes/apps/observability/grafana-cloud/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana-cloud/app/helmrelease.yaml
@@ -28,6 +28,12 @@ spec:
             name: grafana-cloud-credentials
       mounts:
         varlog: true
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          memory: 1Gi
       configMap:
         create: true
         content: |

--- a/vm/observability/docker-compose.yaml
+++ b/vm/observability/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
       - --storage.tsdb.path=/prometheus
       - --storage.tsdb.retention.time=14d
       - --storage.tsdb.retention.size=10GB
+      - --storage.tsdb.out-of-order.time-window=5m
       - --web.enable-remote-write-receiver
       - --web.enable-lifecycle
       - --web.enable-admin-api


### PR DESCRIPTION
**Root cause**: 3 Alloy pods scrape same 31 ServiceMonitors and send to same VM Prometheus. Prometheus defaults out-of-order.time-window=0, so duplicate samples get rejected. Alloy buffers failed retries in memory → 856Mi usage.\n\n**Fixes**:\n1. Set alloy.resources: requests 512Mi, limits 1Gi\n2. Added --storage.tsdb.out-of-order.time-window=5m to VM Prometheus (accept slightly out-of-order samples from multiple Alloy instances)