### PR TITLE
fix(vm): set out_of_order_time_window in prometheus.yml

### DIFF
--- a/vm/observability/docker-compose.yaml
+++ b/vm/observability/docker-compose.yaml
@@ -21,7 +21,6 @@ services:
       - --storage.tsdb.path=/prometheus
       - --storage.tsdb.retention.time=14d
       - --storage.tsdb.retention.size=10GB
-      - --storage.tsdb.out-of-order.time-window=5m
       - --web.enable-remote-write-receiver
       - --web.enable-lifecycle
       - --web.enable-admin-api

--- a/vm/observability/prometheus/prometheus.yml
+++ b/vm/observability/prometheus/prometheus.yml
@@ -3,6 +3,10 @@ global:
   scrape_interval: 30s
   evaluation_interval: 30s
 
+storage:
+  tsdb:
+    out_of_order_time_window: 5m
+
 # Receive metrics via remote_write from Alloy in the cluster
 remote_write: []
 


### PR DESCRIPTION
Replaces invalid CLI flag with correct config file setting. Verified: Prometheus v3.13.1 accepts out_of_order_time_window: 5m via config.