### PR TITLE
chore: upgrade gitbutler skill to v0.21.2, re-add project workflow section

### DIFF
--- a/.opencode/skills/gitbutler/SKILL.md
+++ b/.opencode/skills/gitbutler/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: but
-version: 0.20.4
+version: 0.21.2
 description: "Commit, push, branch, and manage version control with GitButler. Use for commits, selective dirty-file or hunk commits, branches, diffs, PRs, history edits, squashes, amends, undo, merge, apply, and unapply. For selected dirty files or hunks, inspect with `but diff`; use compact `but status` for commit order, branch/stack placement, or conflict overview; use `but status -fv` when file/hunk IDs or per-commit file details matter. Replaces git write commands."
 author: GitButler Team
 ---
@@ -33,44 +33,7 @@ This skill is used inside the home-ops repo, which runs a **medior/senior model*
 
 ## Start Here
 
-Choose the first command by task:
-
-```bash
-# Selected dirty files/hunks:
-but diff
-
-# Commit order, branch layout, conflict overview:
-but status
-
-# Per-commit file details, amend/split details:
-but status -fv
-```
-
-For "commit just/only/specific changes on a new branch", use the fast path:
-
-```bash
-but diff
-but commit <branch> -c -m "<msg>" --changes <id>,<id>
-```
-
-`but commit <branch> -c ... --changes ...` creates the branch and prints the resulting workspace state. Do not run a separate `but branch new`, staging command, status command, or verification diff unless the returned output lacks information you need.
-
-`--changes` (or `-p`) takes comma-separated file or hunk IDs from `but diff` / `but status -fv`; do not invent flags like `--hunk` / `--hunks` or pass change IDs as positional arguments.
-
-## Non-Negotiable Rules
-
-1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that.
-2. After mutations, read the returned output for the updated workspace state — it replaces a follow-up status command.
-3. You may chain `but commit` mutations with `&&` to make several commits from one diff: file/hunk IDs copied from the original output generally remain usable across commits, and branch IDs are stable. Do NOT chain mutations that consume or rewrite commit IDs (`amend`, `squash`, `move`, `uncommit`); those reassign IDs the next command needs, so run one, read the returned workspace state, and take fresh IDs from it. If a chained command cannot resolve an ID, re-read with `but status`/`but diff` and retry.
-4. Use CLI IDs from `but diff` / `but status` / `but status -fv` / `but show`; never hardcode IDs.
-5. Do not run `but status` or `but status -fv` as routine preflight for selected dirty-file or hunk commits. Start with `but diff`; use compact `but status` for commit order, branch/stack placement, or conflict overview. Use `but status -fv` when file/hunk IDs or per-commit file details matter.
-6. For "commit these selected changes on a new branch", prefer one command: `but commit <branch> -c -m "<msg>" --changes <ids>`.
-7. Never commit or push to a branch marked `(merged upstream)`; run `but pull` to remove it, or create/use another branch for new work.
-8. In non-interactive CLI workflows, do not narrate progress between routine commands. Execute the needed `but` commands and give a concise final summary.
-
-## Choose Inspection By Task
-
-Start with the narrowest inspection that answers the task. Avoid ritual status checks.
+Choose the narrowest first command by task; avoid ritual status checks:
 
 ```bash
 # Selected dirty files/hunks:
@@ -88,167 +51,140 @@ but show <id>
 
 Do not run plain `but status` and then `but status -fv` unless the compact output lacks file/hunk details needed for the task.
 
-Perform mutations with IDs from `diff`, `status`, `status -fv`, or `show`:
+For "commit just/only/specific changes on a new branch", use the fast path:
 
 ```bash
-but <mutation> ...
+but diff
+but commit <branch> -c -m "<msg>" --changes <id>,<id>
 ```
+
+`but commit <branch> -c ... --changes ...` creates the branch and prints the resulting workspace state. Do not run a separate `but branch new`, staging command, status command, or verification diff unless the returned output lacks information you need.
+
+## IDs
+
+The first token on each `but diff` / `but status` line is that line's ID — pass it to commands as-is; never hardcode or invent IDs. IDs may be a single character when unambiguous; copy them exactly from command output.
+
+- `--changes` (or `-p`) takes comma-separated file or hunk IDs. A hunk ID is written `<file-id>:<hunk-id>` (e.g. `qs:5`, copied from `but diff`) — the part after the colon is the hunk's ID, **not** a line range (`qs:16-40` is invalid). Do not invent flags like `--hunk` / `--hunks` / `--ids`, pass a line range, or pass the IDs as positional arguments.
+- Commit IDs are stable change IDs that survive history edits (`amend`, `squash`, `move`, `uncommit`, `reword`). Commits without a change ID (e.g. upstream-only) lead with a sha prefix instead, and `#N`-suffixed refs disambiguate duplicates — both go stale after history edits, and a stale sha can silently resolve to the wrong commit. The `(sha …)` on verbose commit lines is informational — do not pass it to commands.
+- File/hunk IDs copied from one diff read generally remain usable across chained commits; branch IDs are stable. If an ID stops resolving, re-read `but status`/`but diff` and retry.
+
+**Chaining:** you may chain mutations with `&&` off one inspection read. Chained `but commit` calls stack in the order written — the first is oldest, each later one goes on top. History edits may run in sequence when every commit ref involved is a change-ID ref; run them one at a time when a ref is sha-based or `#N`-suffixed, or when the next command needs IDs the previous one prints (e.g. recommitting after `but uncommit --diff`). Take follow-up refs from the returned workspace state.
+
+## Non-Negotiable Rules
+
+1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that. Exceptions: `git add -- <path>` to mark a conflicted uncommitted file resolved (see "Conflicts in uncommitted files"), and a worktree-local Git commit when `but commit` reports that linked worktrees are unsupported. Never run `but setup` from a linked worktree.
+2. After a mutation, read the workspace state it returned — it replaces a follow-up status command. Re-run `but status`/`but diff` only if that output lacks the ID you need or files changed since.
+3. Never commit or push to a branch marked `(merged upstream)`; run `but pull` to remove it, or create/use another branch for new work.
+4. In non-interactive CLI workflows, do not narrate progress between routine commands. Execute the needed `but` commands and give a concise final summary.
+5. Avoid `--help` probes; use this skill and `references/reference.md` first. Only use `--help` after a command fails or required syntax is missing from the installed references.
 
 ## Command Patterns
 
 - Commit: `but commit <branch> -m "<msg>" --changes <id>,<id>`
-- Several commits from one diff: chain `but commit` calls - `but commit <branch> -m "<msg>" --changes <id>,<id> && but commit <branch> -m "<msg>" --changes <id>,<id>` (file/hunk IDs from the initial output generally remain usable; refresh if an ID stops resolving)
-- `but commit -a` is accepted as a no-op compatibility flag; GitButler already includes uncommitted changes by default.
+- Several commits from one diff: chain `but commit` calls with `&&` (commits stack oldest-first in the order written)
 - Commit + create branch: `but commit <branch> -c -m "<msg>" --changes <id>`
-- Commit at a specific history position: `but commit <branch> -m "<msg>" --changes <id>,<id> --before <commit-or-branch-id>` or `--after <commit-or-branch-id>`
+- Commit at a specific history position: `... --before <commit-or-branch-id>` or `--after <commit-or-branch-id>`
+- `but commit -a` is accepted as a no-op compatibility flag; GitButler already includes uncommitted changes by default.
 - Amend: `but amend <commit-id> --changes <file-or-hunk-id>,<file-or-hunk-id>`
 - Uncommit and show resulting dirty diff: `but uncommit <commit-id> --diff`
 - Insert empty commit: `but commit empty [-m "<msg>"] [<target>]`
 - Squash commits: `but squash <source-commit-id> [<source-commit-id>...] <target-commit-id> [-m "<msg>"]`
 - Reorder commits: `but move <source-commit-id> <target-commit-id>` (**commit IDs**, not branch names)
-- Reorder multiple commits as a group: `but move <source-commit-id>,<source-commit-id> <target-commit-id>` (comma-separated commit IDs)
-- Move commit to branch top: `but move <commit-id> <branch-name-or-id>` (puts that commit at the top/newest position of the branch)
-- Move multiple commits to branch top: `but move <commit-id>,<commit-id> <branch-name-or-id>` (commit IDs only; not branches)
+- Reorder a block: `but move <source-commit-id>,<source-commit-id> <target-commit-id>` (comma-separated commit IDs)
+- Move commit to branch top: `but move <commit-id> <branch-name-or-id>`
 - Stack branches: `but move <branch-name-or-id> <target-branch-name-or-id>` (**branch names or branch CLI IDs**)
-- Tear off a branch: `but move <branch-name-or-id> zz` (`zz` = uncommitted; branch name or branch CLI ID)
+- Tear off a branch: `but move <branch-name-or-id> zz` (`zz` = uncommitted)
 - Push: `but push <branch-name>` — always specify the branch; bare `but push` pushes ALL branches when run non-interactively
-- Pull: `but pull --check` then `but pull`
-- Create PR: `but pr new <branch-id> [-m "Title..."] [-F pr_message.txt] [-t] [--draft]` — auto-pushes before creating the PR; do not run `but push` first
-- Manage PRs: `but pr auto-merge <selector>`, `but pr set-draft <selector>`, `but pr set-ready <selector>`
+- Pull (update workspace from the target): `but pull` — the output reports the result; `--check` is only a dry-run preview
+- Create PR: `but pr new <branch-id> [-m "Title..."] [-F pr_message.txt] [-t] [--draft]` — auto-pushes first; do not run `but push` before it
 
 ## Task Recipes
 
 ### Update workspace from main
 
-For "get latest from main", "update/sync this workspace", or "pull main":
+For "get latest from main", "update/sync this workspace", "rebase onto main", or "pull main":
 
-1. `but status -fv`
-2. `but pull --check`
-3. If clean, `but pull`
-4. `but status -fv`
+1. `but pull` — one command; no preflight needed. Its output reports the resulting state, it refuses safely when uncommitted changes conflict, and `but undo` reverts it.
+2. If commits come back conflicted, resolve them oldest-first following the printed instructions: `but resolve <commit>`, edit the files, `but resolve finish`. Finishing a lower commit rebases the ones above it, so always work bottom-up.
 
-`but pull` updates applied branches onto the latest target branch (usually
-`main`). Do not use raw `git pull` or `git rebase`.
+Use `but pull --check` only to answer "would this conflict?" without updating (a dry-run preview), not as a step before every pull.
+
+Rebasing applied branches onto the latest target IS `but pull` — never `move`, `config target`, `unapply`, or raw `git pull`/`git rebase`. The base shown in status is the last FETCHED state: when `git log` shows `main` (local or remote) ahead of it, that is exactly the update `but pull` fetches and applies — the target setting is not stale and repointing it is never the fix. Pull carries uncommitted changes along, and its output reports the resulting state. If it refuses because uncommitted changes conflict, park them as printed: `but commit <branch> --changes <ids> -m "wip"`, pull again, then `but uncommit` the parked commit (there is no stash; do not hand-revert files).
 
 ### Commit selected files or hunks
 
-1. `but diff` — use this first for selective dirty commits. It shows file and hunk IDs for uncommitted changes.
-2. Use file IDs when whole files belong in the commit. Use hunk IDs when only part of a file belongs. Do not run plain `but status` first.
-3. For a new branch, use one command: `but commit <branch> -c -m "<msg>" --changes <id1>,<id2>`.
-   For an existing branch, omit `-c`: `but commit <branch> -m "<msg>" --changes <id1>,<id2>`.
-   Omit IDs you don't want committed.
-   Creating a new branch with `-c` does not require a prior `but branch` or `but status -fv`.
-4. **Check the returned status** for remaining uncommitted changes. If the file still appears as uncommitted or assigned to another branch after commit, it may be dependency-locked. See "Stacked dependency / commit-lock recovery" below.
+1. `but diff` — shows file and hunk IDs for uncommitted changes. Do not run plain `but status` first.
+2. Use file IDs when whole files belong in the commit; use hunk IDs (`<file-id>:<hunk-id>`) when only part of a file belongs. Omit IDs you don't want committed.
+3. New branch: `but commit <branch> -c -m "<msg>" --changes <id1>,<id2>` (no prior `but branch new` needed). Existing branch: omit `-c`.
+4. **Check the returned status** for remaining uncommitted changes. If a file you committed still shows as uncommitted, it may be dependency-locked — see "Dependency conflict with another branch".
 
 Edge case: if wanted and unwanted edits are in the same diff hunk, GitButler cannot split that hunk by ID. Only when the task requires keeping part of that hunk uncommitted, temporarily edit the working tree to isolate the wanted lines, commit with `--changes`, then restore the leftover lines so they remain uncommitted.
 
 ### Amend into existing commit
 
-1. `but status -fv` (or `but show <branch-id>`)
-2. Locate file/hunk IDs and target commit ID.
-3. `but amend <commit-id> --changes <file-or-hunk-id>,<file-or-hunk-id>`; use one command for multiple files/hunks that belong in the same commit. To amend into several different commits, run one `but amend` at a time and take fresh commit IDs from the returned status before the next — amending a commit rewrites the IDs of the commits stacked above it.
+1. `but status -fv` (or `but show <branch-id>`) — locate file/hunk IDs and target commit IDs.
+2. `but amend <commit-id> --changes <id>,<id>` — one command per target commit. For several target commits, chain the amends with `&&` when every target is a change-ID ref; otherwise run them one at a time with fresh refs from each returned status.
 
 ### Split an existing commit
 
 Use this when an existing commit should be replaced by selected smaller commits.
 
 1. `but status -fv` when you need the source commit, branch name, or placement anchor.
-2. `but uncommit <source-commit-id> --diff` to expose that commit's changes as uncommitted changes and print committable file/hunk IDs.
-3. Pick replacement commit contents from the dirty diff printed by `but uncommit --diff`, not from the old committed diff.
-4. For multiple replacement commits from the same diff, chain `but commit` calls - file/hunk IDs from the initial output generally remain usable across commits:
-   `but commit <branch> -m "<message 1>" --changes <id>,<id> && but commit <branch> -m "<message 2>" --changes <id>,<id>`
-   Chain them in history order, oldest first; each new commit stacks on top of the previous one. For a specific mid-history position, add `--before <target>`/`--after <target>` and anchor on the branch or an unchanged neighbor commit; if an earlier command in the chain rewrote the anchor, run the rest separately with fresh IDs.
-5. Leave unwanted changes uncommitted. If the returned workspace state shows the requested commits and leftovers, stop; do not run `status`, `diff`, `show`, or `--help` only to reconfirm.
+2. `but uncommit <source-commit-id> --diff` exposes the commit's changes as uncommitted and prints committable file/hunk IDs.
+3. Pick replacement contents from that dirty diff, not from the old committed diff.
+4. Create the replacement commits oldest-first by chaining `but commit` calls. Each new commit goes to the TOP of the stack — if the split commit had commits above it, the replacements now sit above those preserved commits.
+5. **If a commit must stay ABOVE the replacements, put it back on top instead of fighting anchors.** Do not anchor with `--before <top>`/`--after <top>` (sha/`#N` anchors go stale as each insert rewrites history; `--before <branch>` just puts commits on top of the branch). Take the preserved commit's ref from the last returned workspace state, then `but move <preserved-commit-id> <branch>` (several: `but move <id1>,<id2> <branch>`, oldest first).
+6. Leave unwanted changes uncommitted. Remember the returned state lists commits newest first: replacements created oldest-first therefore appear in reverse request order under the preserved commits — that is correct; do not reorder them. Stop when the history matches.
 
 ### Reorder commits
 
-`but move` supports both commit reordering and branch stack operations. Use commit IDs when reordering commits.
-`but status` displays commits newest/top first, while task specs often list history oldest to newest. Use `but status -fv` only if you also need file-level details.
+`but status` displays commits newest/top first, while task specs often list history oldest to newest — translate before moving.
 
-1. `but status`
-2. `but move <source-commit-id> <target-commit-id>` places source immediately before target in oldest-to-newest history. In `but status`, source appears directly below target.
-3. `but move <source-commit-id> <target-commit-id> --after` places source immediately after target in oldest-to-newest history. In `but status`, source appears directly above target.
-4. `but move <source-commit-id> <branch-name-or-id>` moves source to branch top/newest.
-5. `but move <source-commit-id>,<source-commit-id> <target-commit-id>` moves multiple commit sources together. Multi-source moves accept comma-separated commit IDs only, not branch names.
-
-For explicit final-order tasks, run `but status` once to get commit IDs. If the task names an adjacent commit block, do not sort the whole branch or move block members one by one: preserve the block's internal oldest-to-newest order, find the commit that should immediately follow the block in the requested oldest-to-newest order, then run one block move: `but move <oldest-block-id>,<newest-block-id> <following-commit-id>`. After a successful block move, stop if the returned status shows the requested order; do not move the anchor or any member of that block again.
-
-For other explicit reorders, translate the requested order into the newest-to-oldest order shown by `but status`, then make the smallest set of moves. Prefer the default before/below form because it matches the status display: `but move <source> <newer-neighbor>` places source directly below its newer neighbor. Use a branch target only when a commit must become top/newest, and use `--after` only when it clearly avoids extra moves.
+1. `but status` once to get commit IDs (use `-fv` only if you also need file details).
+2. `but move <source> <target-commit>` places source immediately before target in oldest-to-newest history (directly below it in `but status`). `--after` places it immediately after (directly above). `but move <source> <branch>` moves it to branch top/newest.
+3. For an adjacent block, keep the block's internal order and run ONE move: `but move <oldest-block-id>,<newest-block-id> <following-commit-id>` — do not sort the whole branch or move members one by one. After a successful block move, stop if the returned status shows the requested order; do not move the anchor or block members again.
+4. For other reorders, make the smallest set of moves; prefer the default before/below form because it matches the status display.
 
 ### Squash commits
 
-Use this when multiple existing commits should become one commit.
-
-1. `but status` to get commit IDs and current order. Use `but status -fv` only if you also need per-commit file details.
-2. Put the result/target commit last: `but squash <source-commit-id> [<source-commit-id>...] <target-commit-id> -m "<new message>"`.
-3. For multiple independent squash groups, prefer newer/top groups first; history edits can rewrite IDs above the edited commit, so use returned status before the next squash.
-4. After the final squash, stop if returned status shows the requested history; do not run `--help`, `status`, or `status -fv` only to reconfirm.
+1. `but status` for commit IDs and order.
+2. Put the result/target commit last: `but squash <source> [<source>...] <target> -m "<new message>"`.
+3. Multiple independent groups may run in sequence off one status read (targets keep their change-ID refs); prefer newer/top groups first. Take fresh refs only when a ref is sha-based or `#N`-suffixed.
+4. Stop when the returned status shows the requested history; do not re-verify with extra status calls.
 
 ### Stack existing branches
 
-To make one existing branch depend on (stack on top of) another, use top-level `move`:
+To make one existing branch depend on another: `but move <child-branch> <parent-branch>` (branch **names** or branch CLI IDs — commit reordering uses commit IDs). To unstack: `but move <branch> zz`.
 
-```bash
-but move feature/frontend feature/backend
-```
-
-This moves the frontend branch on top of the backend branch in one step.
-
-**DO NOT** use `uncommit` + `branch delete` + `branch new -a` to stack existing branches. That approach fails because git branch names persist even after `but branch delete`. Always use `but move <branch> <target-branch>`.
-
-**To unstack** (make a stacked branch independent again):
-
-```bash
-but move feature/logging zz
-```
-
-**Note:** branch stack/tear-off operations use branch **names** (like `feature/frontend`) or branch CLI IDs, while commit reordering uses commit **IDs** (like `c3`). Do NOT use `but undo` to unstack — it may revert more than intended and lose commits.
+**DO NOT** stack via `uncommit` + `branch delete` + `branch new -a` (git branch names persist after delete and it loses work), and do not use `but undo` to unstack.
 
 ### Create or manage pull requests
 
-`but pr new <branch-id>` pushes the branch and creates a pull request in one step. Do not run `but push` first. Agents must provide `-F pr_message.txt`, `-t`, or `-m` with real newline characters (zsh/bash: `-m $'Title\n\nBody'`) so the command does not open an editor. If forge auth is missing, run `but config forge auth`.
+`but pr new <branch-id>` pushes the branch and creates the PR in one step — no prior `but push`. Provide `-F pr_message.txt`, `-t`, or `-m` with real newlines (zsh/bash: `-m $'Title\n\nBody'`) so no editor opens. If forge auth is missing, run `but config forge auth`.
 
-For independent, unstacked branches, another forge tool may be okay if the user asked for it or `but pr` is unavailable. Still prefer `but pr new` when you are already working from GitButler branch IDs.
+For stacked branches `but pr` is mandatory (it sets PR bases and stack metadata; `gh pr create` breaks that). To publish a whole stack: `but pr new <top-branch-id> -t`. Manage with `but pr auto-merge|set-draft|set-ready <selector>`. See `references/reference.md` for details.
 
-For stacked branches, `but pr` is mandatory. Create and manage stacked PRs with GitButler so PR bases match the stack and GitButler can maintain the stack metadata in PR description footers. Do not create stacked PRs with `gh pr create` or other forge tools.
+### Dependency conflict with another branch
 
-To publish a whole stack, create the PR from the top branch you want published:
+Changes that build on another branch's commits cannot land on an independent branch. `but commit` either creates the commit but reports the change as "could not be applied", or refuses outright — both name the branch the changes depend on and print the exact recovery command.
 
-```bash
-but pr new <top-branch-id> -t
-```
+Recovery: run the printed `but move <your-branch> <dependency-branch>` (full branch **names**) to stack the branches, then commit again with the same `--changes` IDs.
 
-That creates or updates reviews for that branch and its dependencies in stack order. Use `but pr auto-merge <selector>`, `but pr set-draft <selector>`, and `but pr set-ready <selector>` for follow-up PR management; selectors can be branch names, branch IDs, stack IDs, or numeric review IDs.
+If that `but move` fails, do NOT try `uncommit`, `squash`, or `undo` as a workaround — re-run `but status -fv` to confirm both branches exist and are applied, then retry with exact branch names.
 
-### Stacked dependency / commit-lock recovery
+### Resolve conflicted commits (after pull, move, or reorder)
 
-A **dependency lock** occurs when a file was originally committed on branch A, but you're trying to commit changes to it on branch B. Symptoms:
-- `but commit` succeeds but the file still appears in `uncommittedChanges` in the returned status
-- The file still shows as "uncommitted" in the status output
+**NEVER use `git add`, `git commit`, `git checkout --theirs/--ours`, or any git write command during resolution.** Only `but resolve` commands plus direct file edits.
 
-**Recovery:** Stack your branch on the dependency branch, then commit:
+1. Find conflicted commits: the `but pull` summary lists them oldest-first; otherwise `but status` marks them.
+2. `but resolve <commit-id>` — enters resolution mode and prints the conflict regions.
+3. **Edit the files** to remove `<<<<<<<` / `=======` / `>>>>>>>` markers and keep the correct content. Do NOT skip this; do NOT use `but amend` on conflicted commits.
+4. `but resolve finish` — reports leftover markers and surviving uncommitted changes; no follow-up status needed.
+5. Repeat for remaining conflicted commits, oldest first — finishing a lower commit rebases the ones above it.
 
-1. `but status -fv` — identify which branch originally owns the file (check commit history).
-2. `but move <your-branch-name> <dependency-branch-name>` — stack your branch on the dependency. Uses full branch **names**, not CLI IDs.
-3. `but status -fv` — the file should now be committable. Commit it.
-4. `but commit <branch> -m "<msg>" --changes <id>`
+### Conflicts in uncommitted files
 
-**If `but move <branch> <target-branch>` fails:** Do NOT try `uncommit`, `squash`, or `undo` to work around it — these will leave the workspace in a worse state. Instead, re-run `but status -fv` to confirm both branches still exist and are applied, then retry with exact branch names from the status output.
-
-### Resolve conflicts after reorder/move
-
-**NEVER use `git add`, `git commit`, `git checkout --theirs`, `git checkout --ours`, or any git write commands during resolution.** Only use `but resolve` commands and edit files directly with the Edit tool.
-
-If `but move` causes conflicts (conflicted commits in status):
-
-1. `but status -fv` — find commits marked as conflicted.
-2. `but resolve <commit-id>` — enter resolution mode. This puts conflict markers in the files.
-3. **Read the conflicted files** to see the `<<<<<<<` / `=======` / `>>>>>>>` markers.
-4. **Edit the files** to resolve conflicts by choosing the correct content and removing markers.
-5. `but resolve finish` — finalize. Do NOT run this without editing the files first.
-6. Repeat for any remaining conflicted commits.
-
-**Common mistakes:** Do NOT use `but amend` on conflicted commits (it won't work). Do NOT skip step 4 — you must actually edit the files to remove conflict markers before finishing.
+`but status` marks uncommitted files with unresolved merge conflicts `{conflicted}`; they are excluded from committable changes and outside `but resolve` mode. Choose the desired contents or delete the file, then `git add -- <path>` to mark it resolved (the one permitted `git add`).
 
 ## Git-to-But Map
 
@@ -261,14 +197,11 @@ If `but move` causes conflicts (conflicted commits in status):
 | `git rebase -i` | `but move`, `but squash`, `but reword` |
 | `git rebase --onto` | `but move <branch> <new-base>` |
 | `git cherry-pick` | `but pick` |
-| `gh pr create` | `but pr new <branch-id>` (pushes the branch, then creates the PR; no separate `but push`) |
+| `gh pr create` | `but pr new <branch-id>` |
 
 ## Notes
 
-- Use plain `but status` for commit order, branch/stack placement, and conflict overview. Escalate to `but status -fv` only when file/hunk IDs or per-commit file details are needed.
 - Read-only git inspection (`git log`, `git blame`, `git show --stat`) is allowed.
-- After a successful mutation, trust the workspace state it printed. Re-run `but status` or `but status -fv` only if that output lacks the ID you need or files changed since.
-- Avoid `--help` probes; use this skill and `references/reference.md` first. Only use `--help` after a command fails or required syntax is missing from the installed references.
 - If `but` prints an `AGENT ACTION REQUIRED` skill warning, run the suggested command once, then reload/use the GitButler skill. If it repeats, report it instead of retrying.
 - For command syntax and flags: `references/reference.md`
 - For workspace model: `references/concepts.md`

--- a/.opencode/skills/gitbutler/references/concepts.md
+++ b/.opencode/skills/gitbutler/references/concepts.md
@@ -44,17 +44,21 @@ workspace (gitbutler/workspace)
 Every object gets a short, human-readable CLI ID shown in `but status`. IDs are generated per-session and are unique across all entity types (no two objects share an ID) — always read them from `but status`.
 
 ```
-Commits:    1b, 8f, c2     (short hex prefixes of the SHA, long enough to be unique)
+Commits:    1, kyn, mpq#0  (short change-ID prefix when the commit has one, sha prefix otherwise;
+                             a #N suffix disambiguates commits sharing a change ID)
 Branches:   fe, bu, ui     (unique 2–3 char substring of the branch name, e.g. "fe" from "feature-x";
                              falls back to auto-generated ID if no unique substring exists)
-Files:      g0, qs, uo     (derived from the file path, 2–3 chars)
-Hunks:      qs:5, uo:d     (<file-id>:<hunk-id>; the hunk part is derived from the hunk's content)
+Files:      g, qs, uo      (derived from the file path, long enough to be unique)
+Hunks:      g:5, uo:d      (<file-id>:<hunk-id>; the hunk part is derived from the hunk's content)
+Committed files: kyn:n     (<commit-id>:<file-id>, shown under each commit in `but status -fv`)
 Stacks:     m0, n0          (auto-generated, 2–3 chars)
 ```
 
-**Why?** Git commit SHAs are long (40 chars). CLI IDs are short (2-3 chars) and unique within your current workspace context.
+**Why?** Git commit SHAs are long (40 chars). CLI IDs are short, variable-length, and unique within your current workspace context. Commits, files, and hunks may use a single character when that is unambiguous.
 
-**Stability:** File/hunk IDs copied from the current output generally remain usable across ordinary commits, so you can reference several in a row, including across chained `but commit` calls. If an ID stops resolving, re-read the diff and continue. Commit IDs are SHA prefixes that get rewritten by history edits (`amend`, `squash`, `move`, `uncommit`) — amending a commit also gives every commit stacked above it a new ID — so run those one at a time and re-read commit IDs from the returned status rather than chaining.
+**Reading status output:** the first token on each line is that line's ID. Verbose commit lines append an informational `(sha …)` after the timestamp — it changes on every amend; do not pass it to commands.
+
+**Stability:** File/hunk IDs copied from the current output generally remain usable across ordinary commits, so you can reference several in a row, including across chained `but commit` calls. If an ID stops resolving, re-read the diff and continue. Commit IDs are change-ID prefixes when the commit has a change ID and sha prefixes otherwise. Change-ID refs survive history edits (`amend`, `squash`, `move`, `uncommit`, `reword`); sha refs and `#N`-suffixed refs do not — a stale sha can silently resolve to the wrong commit. History edits may run in sequence off one status read when every ref involved is a change-ID ref; otherwise run them one at a time and take the next ref from the returned workspace state.
 
 **Usage:** Pass these IDs as arguments to commands:
 
@@ -126,10 +130,10 @@ The operation performed depends on what you combine:
 
 | Source | Target | Operation              | Example         |
 | ------ | ------ | ---------------------- | --------------- |
-| File   | Commit | Amend file into commit | `but rub a1 c3` |
-| Commit | Commit | Squash commits         | `but rub c2 c3` |
-| Commit | Branch | Move commit to branch  | `but rub c2 bu` |
-| Commit | `zz`   | Undo commit            | `but rub c2 zz` |
+| File   | Commit | Amend file into commit | `but rub a1 nn` |
+| Commit | Commit | Squash commits         | `but rub mm nn` |
+| Commit | Branch | Move commit to branch  | `but rub mm bu` |
+| Commit | `zz`   | Undo commit            | `but rub mm zz` |
 
 `zz` is a special target meaning "uncommitted" (no branch).
 
@@ -160,7 +164,7 @@ The uncommitted change **depends on** C1 (because it calls `foo()`).
 **Implications:**
 
 1. Can't commit this change to a stack that doesn't contain C1
-2. `but absorb` will automatically amend it into C1 (or a commit after C1)
+2. When amending it into history, it belongs in C1 (or a commit after C1)
 3. If you try to move the change, GitButler prevents invalid operations
 
 ### Why This Matters
@@ -176,8 +180,8 @@ Prevents you from creating broken states:
 You can create empty commits:
 
 ```bash
-but commit empty --before c3
-but commit empty --after c3
+but commit empty --before nn
+but commit empty --after nn
 ```
 
 **Use cases:**
@@ -188,7 +192,7 @@ but commit empty --after c3
 Example workflow:
 
 ```bash
-but commit empty --before c5 -m "TODO: Add error handling"
+but commit empty --before rr -m "TODO: Add error handling"
 # Later, amend the error handling changes into the placeholder
 but amend <empty-commit-id> --changes <file-id>
 ```
@@ -257,11 +261,10 @@ When `but pull` causes conflicts, affected commits are marked as conflicted.
 
 ### Resolution Workflow
 
-1. **Identify:** `but status` shows conflicted commits
-2. **Enter mode:** `but resolve <commit-id>`
-3. **Fix conflicts:** Edit files, remove conflict markers
-4. **Check:** `but resolve status` shows remaining conflicts
-5. **Finalize:** `but resolve finish` or `but resolve cancel`
+1. **Identify:** the `but pull` summary lists each conflicted commit's ID, oldest first (`but status` also shows them)
+2. **Enter mode:** `but resolve <commit-id>` — it prints the conflict regions with line numbers. With several conflicted commits, resolve the oldest first: finishing a lower commit rebases the ones above it
+3. **Fix conflicts:** Edit files, remove conflict markers (`but resolve status` re-lists what remains when several files are conflicted)
+4. **Finalize:** `but resolve finish` or `but resolve cancel` — finish reports leftover markers and the surviving uncommitted changes, so no follow-up check is needed
 
 ### During Resolution
 
@@ -288,6 +291,6 @@ Git commands that don't modify state are safe to use:
 - `git commit` - Commits to the workspace merge commit, not your branch
 - `git checkout` - Breaks workspace model
 - `git rebase` - Conflicts with GitButler's management
-- `git merge` - Use `but merge` instead
+- `git merge` - Use `but land` instead
 
 **Rule of thumb:** If it reads, it's fine. If it writes, use `but` instead.

--- a/.opencode/skills/gitbutler/references/examples.md
+++ b/.opencode/skills/gitbutler/references/examples.md
@@ -2,7 +2,7 @@
 
 Real-world examples of common workflows.
 
-**Note on CLI IDs:** Examples below use illustrative IDs like `bu`, `c3`, `a1` to keep commands readable. In practice, **always read actual IDs from `but status -fv`** — they are generated per-session and will differ from these examples. Branch IDs are derived from unique substrings of the branch name (e.g., `fe` from `feature-x`), commit IDs use short hex prefixes (e.g., `1b`, `8f`), and file/hunk/stack IDs are auto-generated (e.g., `g0`, `h0`). All IDs are unique across entity types.
+**Note on CLI IDs:** Examples below use illustrative IDs like `bu`, `nn`, `a1` to keep commands readable. In practice, **always read actual IDs from `but status -fv`** — they are generated per-session and will differ from these examples. Branch IDs are derived from unique substrings of the branch name (e.g., `fe` from `feature-x`), commit IDs are short change-ID prefixes that stay stable across history edits (e.g., `kyn`; commits without a change ID fall back to a sha prefix), and file/hunk/stack IDs are auto-generated (e.g., `r`, `r:c`, `h0`). All IDs are unique across entity types.
 
 ## Example 1: Starting Independent Parallel Work
 
@@ -29,7 +29,7 @@ but commit <api-branch-id> -m "Add user details endpoint" --changes <api-file-id
 but commit <ui-branch-id> -m "Update button hover styles" --changes <ui-file-id>
 
 # Follow-up fix that belongs in a commit you just made? Amend it in.
-# Each mutation returns updated workspace state — take fresh IDs from it before the next command.
+# Each mutation returns updated workspace state — take any new IDs you need from it.
 # but amend <api-commit-id> --changes <api-fix-file-id>,<api-fix-hunk-id>
 
 # 6. Create pull requests (auto-pushes the branches)
@@ -70,9 +70,9 @@ but pr new bv -t
 
 **Result:** Two PRs where user-profile targets add-authentication, with GitButler stack information in the PR descriptions.
 
-## Example 3: Using Absorb Instead of New Commits
+## Example 3: Amending Fixes Into Existing Commits
 
-**Scenario:** Made a small typo fix that should be part of the last commit, not a new commit.
+**Scenario:** Made a small typo fix that should be part of an existing commit, not a new commit.
 
 ```bash
 # 1. Check current commits and uncommitted changes
@@ -81,30 +81,19 @@ but status -fv
 # Output shows:
 # Branch: feature-x (bu)
 # Commits:
-#   c3: Implement feature logic
-#   c2: Add feature tests
+#   nn: Implement feature logic
+#   mm: Add feature tests
 # Uncommitted:
 #   a1: fix-typo.js
 
-# 2. Preview what absorb would do (recommended first step)
-but absorb a1 --dry-run    # Shows where a1 would be absorbed
+# 2. Decide which commit the fix belongs to
+# (the typo is in code introduced by nn, so it belongs in nn)
 
-# 3. Absorb the specific file into appropriate commit
-but absorb a1    # Absorb just this file + get updated status
-
-# GitButler analyzes the change and amends it into c3
-# (because the typo is in code from c3)
+# 3. Amend the file into that commit
+but amend nn --changes a1    # Amend just this file + get updated status
 ```
 
-**Targeted vs blanket absorb:**
-
-```bash
-but absorb a1    # Absorb specific file (recommended)
-but absorb bu    # Absorb all changes assigned to branch bu
-but absorb       # Absorb ALL uncommitted changes (use with caution)
-```
-
-**Why absorb?** Keeps history clean. Small fixes belong in the commits they fix, not as separate "fix typo" commits.
+**Why amend?** Keeps history clean. Small fixes belong in the commits they fix, not as separate "fix typo" commits. You know what you changed and why — pick the target commit yourself.
 
 ## Example 4: Reorganizing Commit History
 
@@ -113,21 +102,21 @@ but absorb       # Absorb ALL uncommitted changes (use with caution)
 **Situation:** Made 5 small WIP commits, want to combine into one logical commit.
 
 ```bash
-# Before:
-# c5: More tweaks
-# c4: Fix another thing
-# c3: Fix tests
-# c2: Adjust logic
-# c1: Initial implementation
+# Before (newest first):
+# rr: More tweaks
+# pp: Fix another thing
+# nn: Fix tests
+# mm: Adjust logic
+# kk: Initial implementation
 
 # Squash all commits in branch
 but squash bu
 
 # Or squash specific range
-but squash c2..c5    # Squashes c2, c3, c4, c5 into one
+but squash mm..rr    # Squashes mm, nn, pp, rr into one
 
 # Or squash specific commits
-but squash c2 c3 c4    # Squashes these three
+but squash mm nn pp    # Squashes these three
 ```
 
 ### Scenario B: Moving Files Between Commits
@@ -139,11 +128,11 @@ but squash c2 c3 c4    # Squashes these three
 but status -fv
 
 # Output shows:
-# c3: api.js, utils.js
-# c2: config.js
+# nn: api.js, utils.js
+# mm: config.js
 
-# 2. Move utils.js from c3 to c2
-but rub a2 c2    # File a2 (utils.js) → commit c2 + get updated status
+# 2. Move utils.js from nn to mm
+but rub a2 mm    # File a2 (utils.js) → commit mm + get updated status
 ```
 
 ### Scenario C: Moving Commit to Different Branch
@@ -156,14 +145,14 @@ but status -fv
 
 # Output:
 # Branch: feature-a (bu)
-#   c3: This should be in feature-b!
-#   c2: Correct commit
+#   nn: This should be in feature-b!
+#   mm: Correct commit
 
 # 2. Create or identify target branch
 but branch new feature-b    # Creates branch bv
 
 # 3. Move the commit
-but move c3 bv    # Move c3 to top of branch bv
+but move nn bv    # Move nn to top of branch bv
 ```
 
 ## Example 5: Stacking Existing Branches
@@ -202,42 +191,35 @@ but commit bv -m "Add dialog component" --changes <id> # To frontend
 but pull
 
 # Output:
-# Conflict in commit c3 on branch feature-x
+# Summary
+# ────────
+#   feature-x - conflicted
+#       nn Add validation
 
-# 2. Check status
-but status -fv
-
-# Output:
-# Branch: feature-x (bu)
-#   c3: Add validation (CONFLICTED)
-
-# 3. Enter resolution mode
-but resolve c3
+# 2. Enter resolution mode using the commit ID from the pull output
+but resolve nn
 
 # Output:
-# Entering resolution mode for commit c3
-# Fix conflicts in: api/users.js, api/validation.js
+# Checking out conflicted commit nn
+# Conflicted files remaining:
+#   ✗ api/users.js
+#      12│<<<<<<< New base: ...
+#      ...conflict regions with line numbers...
 
-# 4. Read each conflicted file and edit to resolve
+# 3. Edit each conflicted file to resolve
 # IMPORTANT: You MUST edit the files — do NOT just run `but resolve finish`
 # NEVER use `git add`, `git checkout --theirs/--ours`, or any git write command — just edit the files directly with the Edit tool, then `but resolve finish`
-cat api/users.js           # Read to see conflict markers
-# (edit to remove <<<<<<< ======= >>>>>>> markers and keep correct content)
+# (edit to remove <<<<<<< ======= >>>>>>> markers and keep correct content;
+#  with several conflicted files, `but resolve status` re-lists what remains)
 
-# 5. Check progress
-but resolve status
-
-# Output:
-# Remaining conflicts:
-#   api/validation.js
-
-# 6. Continue fixing...
-# (resolve last conflict)
-
-# 7. Finalize
+# 4. Finalize
 but resolve finish
 
-# Back to normal workspace mode
+# Output:
+# ✓ Conflict resolution finalized successfully!
+# No conflict markers remain in the resolved files.
+# Workspace restored; uncommitted changes intact: ...
+# No follow-up status or marker scan needed — finish already reports both.
 ```
 
 ## Example 7: Complete Feature Development Workflow
@@ -267,7 +249,7 @@ but commit bu -m "Style dashboard components" --changes <file-ids>
 
 # 7. Make small fix
 # (fix typo in widget)
-but absorb a1    # Absorb specific file into appropriate commit
+but amend <commit-id> --changes a1    # Amend fix into the commit it belongs to
 
 # 8. Clean up if needed
 but squash bu    # Combine all commits (optional)
@@ -324,31 +306,32 @@ but resolve ...
 # 1. Current state
 but status -fv
 
-# Output:
+# Output (newest first):
 # Branch: feature-x (bu)
-#   c5: final commit
-#   c4: WIP
-#   c3: Fix stuff
-#   c2: Another fix
-#   c1: Initial
+#   rr: final commit
+#   pp: WIP
+#   nn: Fix stuff
+#   mm: Another fix
+#   kk: Initial
 
-# 2. Reword commit messages
-but reword c4 -m "Add validation logic"
-but reword c3 -m "Fix edge case in parser"
-but reword c2 -m "Update error messages"
+# 2. Reword commit messages — commit refs are change-ID based and stay
+#    valid across rewords and other history edits
+but reword pp -m "Add validation logic"
+but reword nn -m "Fix edge case in parser"
+but reword mm -m "Update error messages"
 
-# 3. Move c5 to be earlier
-but move c5 c3    # Move c5 before c3
+# 3. Move rr to be earlier
+but move rr nn    # Move rr before nn
 
 # 4. Squash similar commits
-but squash c2 c3    # Combine error handling commits
+but squash mm nn    # Combine error handling commits; target nn keeps its ref
 
-# Output:
+# Output (newest first):
 # Branch: feature-x (bu)
-#   c4: Add validation logic
-#   c3: final commit
-#   c2: Fix edge case in parser and update error messages
-#   c1: Initial
+#   pp: Add validation logic
+#   nn: Fix edge case in parser and update error messages
+#   rr: final commit
+#   kk: Initial
 
 # 5. Push clean history
 but push feature-x
@@ -372,7 +355,7 @@ but commit bu -m "Identify auth bug source" --changes <file-ids>
 # (make more changes)
 but commit bu -m "Fix token expiration handling" --changes <file-ids>
 # (small fix to existing code)
-but absorb a1              # Absorb specific fix into appropriate commit
+but amend <commit-id> --changes a1  # Amend fix into the commit it belongs to
 
 # Mid-day: Start urgent fix on different branch
 but branch new hotfix-login  # Parallel branch for urgent work
@@ -390,9 +373,7 @@ but pr new bu      # Push and create PR
 
 # After PR review: Make requested changes
 # (make changes based on feedback)
-but absorb <file-id>    # Absorb specific changes into commits
-# Or absorb all changes for this branch:
-but absorb bu          # Absorb all changes assigned to bu
+but amend <commit-id> --changes <file-id>  # Amend each fix into the commit it belongs to
 but push fix-auth-bug   # Push updated history
 ```
 
@@ -419,7 +400,7 @@ but oplog
 # Output:
 # s5: squash branch bu
 # s4: commit bu "message"
-# s3: amend a1 into c2
+# s3: amend a1 into mm
 # s2: create branch bu
 # s1: pull from remote
 
@@ -452,7 +433,6 @@ but status -fv    # File-centric view for quick overview
 ### Preview Before Doing
 
 ```bash
-but absorb <file-id> --dry-run  # See where specific file would be absorbed
 but push my-feature --dry-run   # See what would be pushed
 ```
 
@@ -469,10 +449,14 @@ but commit my-branch -m "Add parser" --changes qs:5,qs:2 \
   && but commit my-branch -m "Add tests" --changes uo:d
 ```
 
-Only chain when each command references uncommitted IDs (plus the stable branch ID).
-If an ID stops resolving, re-read the diff and continue.
-Mutations that consume commit IDs — `amend`, `squash`, `move`, `uncommit` — rewrite
-those IDs, so run them one at a time and take fresh IDs from returned status.
+The commits stack in the order you write them, so `Add parser` ends up below (older
+than) `Add tests`. Chain these commit commands when each references uncommitted IDs
+(plus the stable branch ID). If an ID stops resolving, re-read the diff and continue.
+History edits — `amend`, `squash`, `move`, `uncommit`, `reword` — may also run in
+sequence off one status read when every commit ref involved is a change-ID ref;
+those stay stable across the edits. Run them one at a time when a ref is sha-based
+or `#N`-suffixed, or when the next command needs IDs the previous one prints, and
+take follow-up refs from the returned workspace state.
 
 
 ### Auto-completion

--- a/.opencode/skills/gitbutler/references/reference.md
+++ b/.opencode/skills/gitbutler/references/reference.md
@@ -6,10 +6,10 @@ Agent-focused reference for useful `but` commands.
 
 - [Inspection](#inspection-understanding-state) - `status`, `show`, `diff`
 - [Branching](#branching) - `branch new`, `apply`, `unapply`, `branch delete`, `pick`
-- [Committing](#committing) - `commit`, `absorb`
+- [Committing](#committing) - `commit`
 - [Editing History](#editing-history) - `rub`, `squash`, `amend`, `move`, `uncommit`, `reword`, `discard`
 - [Conflict Resolution](#conflict-resolution) - `resolve`
-- [Remote Operations](#remote-operations) - `push`, `pull`, `pr`, `merge`
+- [Remote Operations](#remote-operations) - `push`, `pull`, `pr`, `land`
 - [Workspace Maintenance](#workspace-maintenance) - `clean`
 - [History & Undo](#history--undo) - `undo`, `oplog`
 - [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `update`, `skill`, `gui`
@@ -34,6 +34,8 @@ Shows:
 - Uncommitted and assigned changes
 - Commits on each stack
 - CLI IDs to use in other commands
+
+The first token on each line is that line's ID. Commit lines lead with the commit's change ID (stable across history edits); commits without a change ID lead with a sha prefix, which goes stale after history edits. Verbose output appends an informational `(sha …)` after the timestamp — do not pass the sha to commands.
 
 ### `but show <id>`
 
@@ -136,7 +138,7 @@ Cherry-pick commits from unapplied branches into applied branches.
 
 ```bash
 but pick <commit-sha> <branch>       # Pick specific commit into branch
-but pick <cli-id> <branch>           # Pick using CLI ID (e.g., "c5")
+but pick <cli-id> <branch>           # Pick using CLI ID (e.g., "nn")
 but pick <unapplied-branch>          # Interactive commit selection from branch
 but pick <commit-sha>                # Auto-select target if only one branch
 ```
@@ -173,6 +175,8 @@ but commit empty --after <target>        # Insert empty commit after target
 
 **Important:** Plain `but commit <branch> -m` commits ALL uncommitted changes to the branch. Use `--changes` to commit only specific files or hunks.
 
+`but commit` is not supported from linked worktrees. Use Git directly for the worktree-local commit, and do not run `but setup` there.
+
 **Committing specific files or hunks:** Start with `but diff` for selective dirty commits, then use `--changes` (or `-p`) with comma-separated CLI IDs to commit only those files or hunks:
 - **File IDs** from `but diff` or `but status -fv`: commits entire files
 - **Hunk IDs** from `but diff`: commits individual hunks
@@ -180,9 +184,9 @@ but commit empty --after <target>        # Insert empty commit after target
 
 **Creating branches on commit:** Use `-c` / `--create` to create a new branch for the commit. If the branch name matches an existing branch, that branch is used instead.
 
-**Placing commits:** Use `--before <target>` or `--after <target>` when the new commit should be inserted at a specific position in existing history. After an insertion, later commit IDs may be rewritten; use fresh IDs from returned status output for subsequent history edits.
+**Placing commits:** Use `--before <target>` or `--after <target>` when the new commit should be inserted at a specific position in existing history. Change-ID refs of existing commits remain valid after an insertion; sha and `#N`-suffixed refs may go stale — use refs from the returned status output for subsequent history edits.
 
-**Several commits from one diff:** Chain `but commit` calls with `&&` to split a broad uncommitted change into several semantic commits: `but commit <branch> -m "msg1" --changes a1,b2 && but commit <branch> -m "msg2" --changes c3,d4`. File/hunk IDs copied from the original output generally remain usable across commits; if an ID stops resolving, re-read the diff and continue. Do not chain mutations that consume commit IDs (`amend`, `squash`, `move`, `uncommit`) — those get rewritten, so run them one at a time.
+**Several commits from one diff:** Chain `but commit` calls with `&&` to split a broad uncommitted change into several semantic commits: `but commit <branch> -m "msg1" --changes a1,b2 && but commit <branch> -m "msg2" --changes c3,d4`. The commits stack in the order you write them — the first `but commit` is the oldest of the new commits and each later one goes on top (newest). File/hunk IDs copied from the original output generally remain usable across commits; if an ID stops resolving, re-read the diff and continue. History edits (`amend`, `squash`, `move`, `uncommit`, `reword`) may run in sequence off one status read when every commit ref involved is a change-ID ref; run them one at a time when a ref is sha-based or `#N`-suffixed, or when the next command needs IDs the previous one prints, and take follow-up refs from the returned workspace state. If a commit must stay *above* the new ones, see "Split an existing commit" in SKILL.md: commit them, then `but move <preserved-commit-id> <branch>` rather than anchoring with `--before`/`--after`.
 
 Example: `but commit my-branch -m "Fix bug" --changes ab,cd` commits files/hunks `ab` and `cd`.
 
@@ -193,26 +197,6 @@ To commit specific hunks from a file with multiple changes, use `but diff` to se
 Edge case: if wanted and unwanted edits are in the same hunk, GitButler cannot split that hunk by ID. Only when the task requires keeping part of that hunk uncommitted, temporarily edit the working tree to isolate the wanted lines, commit with `--changes`, then restore the leftover lines so they remain uncommitted.
 
 If only one branch is applied, you can omit the branch ID.
-
-### `but absorb [source]`
-
-Automatically amend uncommitted changes into existing commits.
-
-```bash
-but absorb <file-id>          # Absorb specific file (recommended)
-but absorb <branch-id>        # Absorb all changes assigned to this branch
-but absorb                    # Absorb ALL uncommitted changes (use with caution)
-but absorb --dry-run          # Preview without making changes
-but absorb <file-id> --dry-run  # Preview specific file absorption
-```
-
-**Recommendation:** Prefer targeted absorb (`but absorb <file-id>`) over absorbing everything. Running `but absorb` without arguments absorbs ALL uncommitted changes across all branches, which may not be what you want.
-
-Logic:
-
-- Changes amended into topmost commit of their branch
-- Changes depending on specific commit amended into that commit
-- Uses smart matching to find appropriate commits
 
 ## Editing History
 
@@ -249,9 +233,10 @@ but squash <branch> -i                          # Squash with AI-generated commi
 ```
 
 Use explicit IDs when the target commit must be unambiguous. For multiple
-independent squash groups, prefer newer/top groups first; history edits can
-rewrite IDs above the edited commit, so use returned status before the next
-squash.
+independent squash groups, prefer newer/top groups first; change-ID refs from
+one status read stay valid across squashes (the target keeps its ref), so the
+groups may run in sequence — take fresh refs from the returned status only
+when a ref is sha-based or `#N`-suffixed.
 
 ### `but amend <commit> --changes <file>[,<file>...]`
 
@@ -261,9 +246,7 @@ Amend one or more files/hunks into a specific commit. Use when you know exactly 
 but amend <commit-id> --changes <file-id>,<hunk-id>
 ```
 
-**When to use `amend` vs `absorb`:**
-- `but amend` - You know the target commit; explicit control
-- `but absorb` - Let GitButler auto-detect the target; smart matching based on dependencies
+Decide the target commit yourself: check `but status -fv`, find the commit the change logically belongs to, then amend into it.
 
 Convenience wrapper around `rub` for amending uncommitted files or hunks into a known commit.
 
@@ -320,7 +303,7 @@ but discard <hunk-id>         # Discard hunk changes
 
 ## Conflict Resolution
 
-When commits have conflicts (shown in `but status` — look for commits marked as conflicted):
+When commits have conflicts (the `but pull` summary lists them; `but status` marks them as conflicted):
 
 ### `but resolve <commit>`
 
@@ -357,12 +340,10 @@ but resolve cancel --force
 
 **Workflow:**
 
-1. `but status` — identify conflicted commits (marked as conflicted in the output)
-2. `but resolve <commit-id>` — enter resolution mode for the conflicted commit
-3. Edit the conflicted files — remove `<<<<<<<`, `=======`, `>>>>>>>` markers and keep the correct content
-4. `but resolve status` — verify no conflicts remain
-5. `but resolve finish` — finalize and return to normal mode
-6. If multiple commits are conflicted, repeat steps 2-5 for each one
+1. `but resolve <commit-id>` — enter resolution mode using the commit ID from the `but pull` summary (or `but status`); the conflict regions are printed with line numbers
+2. Edit the conflicted files — remove `<<<<<<<`, `=======`, `>>>>>>>` markers and keep the correct content (`but resolve status` re-lists what remains when several files are conflicted)
+3. `but resolve finish` — finalize and return to normal mode; the output reports leftover markers and the surviving uncommitted changes, so no follow-up status is needed
+4. If multiple commits are conflicted, repeat steps 1-3 for each one, oldest commit first — finishing a lower commit rebases the ones above it
 
 **Important:** Never use `git add`, `git commit`, or other git write commands during conflict resolution. Only use `but resolve` commands and edit files directly.
 
@@ -388,11 +369,12 @@ Use this for "get latest from main" in a GitButler workspace.
 
 ```bash
 but pull                      # Fetch and rebase applied branches
-but pull --check              # Check if can merge cleanly (no changes)
+but pull --check              # Dry-run preview: report what would happen, change nothing
 ```
 
-Run `but pull --check` first, then `but pull` if clean. Do not use raw
-`git pull` or `git rebase`.
+Run `but pull` directly; its output reports the result and `but undo`
+reverts it. Use `--check` only when you want a preview without updating.
+Do not use raw `git pull` or `git rebase`.
 
 ### `but pr`
 
@@ -423,15 +405,18 @@ Agents must use `--message (-m)`, `--file (-F)`, or `--default (-t)` to avoid ed
 
 Requires forge integration to be configured via `but config forge auth`.
 
-### `but merge <branch>`
+### `but land <branch>`
 
-Merge branch into local target branch.
+Land a branch directly onto the target (e.g. `origin/master`), skipping a pull request. Fast-forwards
+when possible, otherwise makes a signed merge commit; for a `gb-local` target it moves the refs
+locally. Then reconciles the remaining branches like `but pull`.
 
 ```bash
-but merge <branch-id>
+but land <branch-id> --yes            # Land onto the target (--yes required non-interactively)
+but land <branch-id> --no-ff --yes    # Force a merge commit instead of fast-forwarding
 ```
 
-Merges into local target branch, then runs `but pull` to update.
+Direct target updates are hard to reverse, so confirmation is required (agents must pass `--yes`).
 
 ## Workspace Maintenance
 
@@ -493,7 +478,11 @@ but setup
 but setup --init              # Also initialize a new git repo if none exists
 ```
 
-Converts regular git repo to use GitButler workspace model. Use `--init` in non-interactive environments (CI/CD) to ensure a git repository exists before setup.
+Converts a regular Git repository to the managed GitButler workspace model. Use `--init` in
+non-interactive environments (CI/CD) to ensure a Git repository exists before setup. When the
+experimental single-branch feature is enabled, normal CLI use does not require this command: the
+repository is registered and its target is inferred lazily without checking out
+`gitbutler/workspace` or installing setup hooks.
 
 ### `but teardown`
 
@@ -509,8 +498,15 @@ View and manage GitButler configuration.
 
 ```bash
 but config
-but config user               # Also: forge, target, metrics, ui, ai
+but config user               # Also: forge, target, metrics, feature, ui, ai
 but config ai openai          # Also: anthropic, ollama, lmstudio, openrouter
+but config target             # Show the current target branch
+but config target origin/main # Set the fetch target
+but config push-remote         # Show the current push remote
+but config push-remote origin  # Set the push remote without changing the target
+but config feature                         # List configurable feature flags
+but config feature single-branch           # Show a feature flag's value
+but config feature single-branch enable    # Also: disable
 ```
 
 ### `but update check`


### PR DESCRIPTION
Upgrade the vendored GitButler skill from v0.20.4 to v0.21.2 and re-apply
the project-specific "Project workflow" section on top (medior/senior
model, never-auto-merge guardrail, default commit/PR flow).