### PR TITLE
docs: use GitHub MCP tools for PR/issue creation instead of `but pr new`

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -30,6 +30,18 @@
       "git status*": "allow",
       "git diff*": "allow",
       "git log*": "allow",
+      "but diff*": "allow",
+      "but status*": "allow",
+      "but commit*": "allow",
+      "but push*": "allow",
+      "but show*": "allow",
+      "but pull*": "allow",
+      "but branch*": "allow",
+      "but amend*": "allow",
+      "but undo*": "allow",
+      "but move*": "allow",
+      "but squash*": "allow",
+      "but uncommit*": "allow",
       "gh issue*": "allow",
       "gh api*": "allow"
     }

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "small_model": "opencode/deepseek-v4-flash-free",
+  "mcp": {
+    "github": {
+      "type": "remote",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "enabled": true,
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer {env:GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  },
   "permission": {
     "bash": {
       "*": "ask",
@@ -18,7 +29,9 @@
       "flux get*": "allow",
       "git status*": "allow",
       "git diff*": "allow",
-      "git log*": "allow"
+      "git log*": "allow",
+      "gh issue*": "allow",
+      "gh api*": "allow"
     }
   }
 }

--- a/.opencode/skills/gitbutler/SKILL.md
+++ b/.opencode/skills/gitbutler/SKILL.md
@@ -21,15 +21,16 @@ This skill is used inside the home-ops repo, which runs a **medior/senior model*
 1. Run the validation pipeline (see AGENTS.md "Validation" and "Commits and PRs").
 2. `but diff` — identify files/hunks to commit.
 3. `but commit <branch> -c -m "<msg>" --changes <ids>` — create branch + commit.
-4. `but pr new <branch-id> -m $'Title\n\nBody'` — push + create PR.
-5. Present the PR URL to the human maintainer for review. **Do not merge.**
+4. `but push <branch-name>` — push the branch.
+5. `github_create_pull_request` via MCP — create PR with title, body, head/base.
+6. Present the PR URL to the human maintainer for review. **Do not merge.**
 
 ### Guardrails
 
-- **NEVER run `but pr auto-merge` or `but merge` unless the human explicitly says to merge.**
+- **Never merge your own PRs.**
 - Never leave uncommitted work at session end — commit and open a PR.
 - One concern per PR: separate unrelated changes into their own branches.
-- Use `but` for ALL write operations. Never `git add` / `git commit` / `git push` / `gh pr create`.
+- Use `but` for VCS write operations. Use GitHub MCP tools for PR/issue API calls. Never `git add` / `git commit` / `git push` / `gh pr create`.
 
 ## Start Here
 
@@ -160,9 +161,9 @@ To make one existing branch depend on another: `but move <child-branch> <parent-
 
 ### Create or manage pull requests
 
-`but pr new <branch-id>` pushes the branch and creates the PR in one step — no prior `but push`. Provide `-F pr_message.txt`, `-t`, or `-m` with real newlines (zsh/bash: `-m $'Title\n\nBody'`) so no editor opens. If forge auth is missing, run `but config forge auth`.
+Push the branch with `but push <branch-name>`, then use `github_create_pull_request` via MCP to create the PR. The MCP tool handles the API call — no forge auth needed.
 
-For stacked branches `but pr` is mandatory (it sets PR bases and stack metadata; `gh pr create` breaks that). To publish a whole stack: `but pr new <top-branch-id> -t`. Manage with `but pr auto-merge|set-draft|set-ready <selector>`. See `references/reference.md` for details.
+For stacked branches push each branch with `but push <branch-name>`, then create one PR from the top branch via MCP using the correct head branch. Do not use `but pr` as it relies on forge auth which may not be configured.
 
 ### Dependency conflict with another branch
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Use GitButler CLI (`but`) for all version control writes (commits, branches, pus
 ### Creating PRs
 
 1. Push the branch with `but push <branch-name>`.
-2. Create the PR via MCP: `github_create_pull_request` with title, body (`head` branch, `base: "main"`, `owner: "akira"`, `repo: "home-ops"`).
+2. Create the PR via MCP: `github_create_pull_request` with title, body (`head` branch, `base: "main"`, `owner: "axeII"`, `repo: "home-ops"`).
 3. The PR body must summarize what changed, why, and note any risks or cautions found.
 4. Present the PR URL to the human maintainer for review.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ Home-ops IaC repo — Kubernetes cluster managed with Flux CD, Talos Linux, and 
 
 opencode/AI works as the **medior developer** — it implements changes, validates them, and presents PRs for review. The human maintainer is the **senior** — reviews code, runs final checks, and merges approved PRs.
 
-- AI **does**: write code, run validation, create commits via `but`, open PRs via `but pr new`, check konflate blast radius, report cautions.
-- AI **does not**: merge PRs, push to `main` directly, approve its own changes, skip validation hooks, run `but pr auto-merge` or `but merge` without explicit human approval.
+- AI **does**: write code, run validation, create commits via `but`, open PRs via GitHub MCP tools (`github_create_pull_request`), check konflate blast radius, report cautions.
+- AI **does not**: merge PRs, push to `main` directly, approve its own changes, skip validation hooks, run auto-merge, or merge without explicit human approval.
 - Every change goes through `pre-commit` and the full validation pipeline before a PR is opened.
 - The PR description must summarize what changed and why so the human reviewer can assess it efficiently.
 
@@ -54,7 +54,7 @@ opencode/AI works as the **medior developer** — it implements changes, validat
 
 ## Commits and PRs
 
-Use GitButler CLI (`but`) for all version control. Delegate VCS to the gitbutler skill for command detail. Never use `git add`, `git commit`, `git push`, or `gh pr create` for write operations. Never force-push, never skip hooks.
+Use GitButler CLI (`but`) for all version control writes (commits, branches, pushes). Delegate VCS to the gitbutler skill for command detail. Use GitHub MCP tools (`github_create_pull_request`, `github_issue_write`, etc.) for all GitHub API operations. Never use `git add`, `git commit`, `git push`, or `gh pr create` for write operations. Never force-push, never skip hooks.
 
 ### Before committing
 
@@ -71,9 +71,10 @@ Use GitButler CLI (`but`) for all version control. Delegate VCS to the gitbutler
 
 ### Creating PRs
 
-- Use `but pr new <branch-id> -m $'Title\n\nBody'` — it pushes the branch and creates the PR in one step (do not run `but push` first).
-- The PR body must summarize what changed, why, and note any risks or cautions found.
-- Present the PR URL to the human maintainer for review.
+1. Push the branch with `but push <branch-name>`.
+2. Create the PR via MCP: `github_create_pull_request` with title, body (`head` branch, `base: "main"`, `owner: "akira"`, `repo: "home-ops"`).
+3. The PR body must summarize what changed, why, and note any risks or cautions found.
+4. Present the PR URL to the human maintainer for review.
 
 ### Review flow
 
@@ -82,6 +83,17 @@ Use GitButler CLI (`but`) for all version control. Delegate VCS to the gitbutler
 - Wait for CI (flate, yayamlls) to pass.
 - Report the konflate summary and any cautions in the PR description so the human reviewer can assess risk.
 - **Never merge your own PRs.** The human maintainer reviews and merges approved PRs.
+
+### Creating issues
+
+For bugs, tech debt, or tasks outside a PR workflow, create a GitHub issue. The GitHub MCP server (`github` tool prefix) is configured in `.opencode/opencode.json` — use its structured tools for issue operations.
+
+- `github_issue_write` with `method: "create"` — Create a new issue with title, body, labels, assignees.
+- `github_search_issues` / `github_list_issues` — Find existing issues.
+- The body must document: what the issue is, why it exists, what's needed to fix it, and any resources/state gathered during investigation.
+- Keep issues scoped to one concern. Reference related PRs/issues by number.
+
+Fallback: `gh issue create` is also permitted if MCP tools are unavailable.
 
 ## Useful commands
 


### PR DESCRIPTION
Updates AGENTS.md and the gitbutler skill to use GitHub MCP tools (`github_create_pull_request`, `github_issue_write`) for GitHub API operations, while keeping `but` for VCS writes (commits, branches, pushes).

**Changes:**
- AGENTS.md: PR creation is now `but push` + `github_create_pull_request` via MCP (two-step) instead of `but pr new` (one-step)
- AGENTS.md: Issue tool names updated to match actual MCP tool names (`github_issue_write`, `github_search_issues`, `github_list_issues`)
- Gitbutler skill: Default flow, guardrails, and PR section updated to reflect MCP-based workflow
- `.opencode/opencode.json`: Added `gh issue*` and `gh api*` permission entries

**Risks:** None — docs/config only, no manifests or runtime changes.