### PR TITLE
fix(karakeep): rename meilisearch dumpless-upgrade flag for v1.51 compatibility

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -105,7 +105,7 @@ spec:
               tag: v1.51.0
             args:
               - /bin/meilisearch
-              - --experimental-dumpless-upgrade
+              - --upgrade-db
             env:
               MEILI_NO_ANALYTICS: true
               MEILI_MASTER_KEY:


### PR DESCRIPTION
### What

Meilisearch v1.51.0 (auto-merged this morning in the Friday release train) stabilized the experimental dumpless-upgrade feature, **renaming** the flag `--experimental-dumpless-upgrade` → `--upgrade-db`.

The pod has been CrashLoopBackOff since rollout with:
```
error: unexpected argument '--experimental-dumpless-upgrade' found
exit code 2
```

### Change

`kubernetes/apps/default/karakeep/app/helmrelease.yaml:108` — rename one container arg:
```diff
- - --experimental-dumpless-upgrade
+ - --upgrade-db
```

Kept permanently (same pattern as before: rename from experimental to stable flag, enabling in-place DB upgrades for future minor version bumps without dump/restore).

### After merge

Flux reconciles → pod starts → meilisearch upgrades its v1.50-format database in place → `karakeep-meilisearch` service regains endpoints → karakeep full-text search restored.

If the in-place upgrade fails for any reason, rollback: delete the `meili_data` subPath from the `karakeep` PVC (the search index is rebuildable from karakeep data — no source data loss).

### Blast radius

- 1 HelmRelease (`default/karakeep`)
- 1 pod restart (meilisearch sidecar)
- No dependent apps restarted