### PR TITLE
fix(ci): repair auto-merge critical-infra gate (missing grep -E) + defense-in-depth label gate

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -147,8 +147,15 @@ jobs:
 
             # ── Manual filters ──────────────────────────────────
             # rook-ceph / ceph image by title or branch
-            if echo "${title}" | grep -qi "${MANUAL_TITLE_REGEX}" || echo "${branch}" | grep -qi "${MANUAL_TITLE_REGEX}"; then
-              echo "  → SKIP (manual: ceph)"
+            if echo "${title}" | grep -qiE "${MANUAL_TITLE_REGEX}" || echo "${branch}" | grep -qiE "${MANUAL_TITLE_REGEX}"; then
+              echo "  → SKIP (manual: critical infra)"
+              skipped_manual+=("#${number}")
+              continue
+            fi
+
+            # needs-review label (set by pr-classify; defense in depth)
+            if [[ ",${labels_str}," == *",needs-review,"* ]]; then
+              echo "  → SKIP (manual: needs-review label)"
               skipped_manual+=("#${number}")
               continue
             fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,13 +117,14 @@ The `.github/workflows/auto-merge.yaml` workflow runs daily at 02:00 UTC and app
 | **minor** (release train) | `type/minor` | **3d** | **Fri–Sat** (Europe/Berlin) | no failures, no cautions |
 | **major (ci/gh-action)** | `type/major` + `renovate/github-action` | **2d** | any | no failures (cautions allowed) |
 | **major (other)** | `type/major`, not `renovate/github-action` | — | MANUAL | — |
-| **rook-ceph** | title/branch matches `rook-ceph` | — | MANUAL | — |
+| **critical infra** | `needs-review` label, or title/branch matches `ceph\|cilium\|flux\|dragonfly` | — | MANUAL | — |
 | **area/talos** | `area/talos` label (`talos/**`) | — | MANUAL | — |
 
 - **Cluster quiet window:** Sun 00:00–05:00 UTC — no merges (Talos upgrade window).
 - **Sleep between merges:** 300 seconds to let Flux reconcile before the next merge.
 - Konflate re-render is triggered before each merge gate via `KONFLATE_PUSH_TOKEN`.
 - **Bulk merge** (`.github/workflows/bulk-merge-prs.yaml`) also excludes rook-ceph, `area/talos`, `type/major`, `type/minor`, and `hold`.
+- **Defense in depth:** The `pr-classify` workflow applies `needs-review` and `risk/critical` labels to critical-infra PRs. Auto-merge hard-skips any PR with the `needs-review` label regardless of the title/branch regex — two independent detection layers must both fail for a critical upgrade to auto-merge.
 - **Konflate** is reachable only from inside the home network (private IP). From GitHub Actions, the konflate gate is skipped — the auto-merge relies on label/age/day rules alone. `Konflate` as a required status check in branch protection won't work from outside the network.
 - **Konflate write-back** posts a summary PR comment + commit status after each render when reachable (inside the network).
 - **Setup:** add `KONFLATE_PUSH_TOKEN` (random 32-byte hex) to 1Password `konflate` item and as a GitHub Actions secret; confirm the GitHub App has `checks: write` + `pull-requests: write` permissions.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ _... automated via [Flux](https://github.com/fluxcd/flux2), [Renovate](https://g
 
 ## 🤔 What is this?
 
-A production-grade Kubernetes homelab running real services - fully managed as code, automated as possible, and open source to show everyone how to break k8s :D. This repository is the single source of truth for the cluster: every deployment, every network policy, and every secret lives here (some are SOPS encrypted others use 1password connection). Renovate opens PRs, konflate reviews them, CI validates them, and the auto-merge pipeline lands safe changes without human toil. The cluster reconciles itself through Flux. 
+A production-grade Kubernetes homelab running real services - fully managed as code, automated as possible, and open source to show everyone how to break k8s :D. This repository is the single source of truth for the cluster: every deployment, every network policy, and every secret lives here (some are SOPS encrypted others use 1password connection). Renovate opens PRs, konflate reviews them, CI validates them, and the auto-merge pipeline lands safe changes without human toil. The cluster reconciles itself through Flux.
 
 > _Side note_: Though I mentioned this is automated some PRs like cilium upgrade, rook update are very critical and I have minimal time for my cluster and cannot jump in when PR automatically breaks my cluster for that reason I have three types of PR - automated, deployed during release train (Friday/Saturday as during the weekend I can fix stuff) and critical which can be merged only by me. This way I try to safely automate as possible the upgrade process.
 


### PR DESCRIPTION
### The bug

`auto-merge.yaml:150` uses `grep -qi` (Basic Regex) against a pattern containing `|`:
```bash
MANUAL_TITLE_REGEX="ceph|cilium|flux|dragonfly"
...
grep -qi "${MANUAL_TITLE_REGEX}"  # | is LITERAL in BRE — never matches
```

With BRE, `|` is a literal character. The pattern only matches the exact string `ceph|cilium|flux|dragonfly` → **the manual-infra filter has been dead since July 6, 2026** (commit `2a83d1a96` introduced the first `|`).

For contrast, every other workflow with a similar pattern uses `-E` correctly:
- `pr-classify.yaml:70` — `grep -qiE` ✓
- `bulk-merge-prs.yaml:51` — `grep -qiE` ✓

### What slipped through

All merged by `bot-akira[bot]` when they should have been manual:

| PR | What | When | Severity |
|---|---|---|---|
| [#3706](https://github.com/axeII/home-ops/pull/3706) | rook-ceph v1.20.2→v1.20.3 (patch) | Today 05:36Z | ⚠️ manual per policy |
| [#3705](https://github.com/axeII/home-ops/pull/3705) | rook/ceph image v1.20.2→v1.20.3 (patch) | Today 05:41Z | ⚠️ manual per policy |
| [#3701](https://github.com/axeII/home-ops/pull/3701) | **flux-operator 0.55→0.57 (minor)** | Today 06:07Z | 🚨 minor GitOps-core auto-merged |
| [#3675](https://github.com/axeII/home-ops/pull/3675) | flux distribution v2.9.2→v2.9.3 (patch) | Jul 26 | ⚠️ "fluxcd" contains "flux" |

No actual damage this time — rook-ceph healthy at v1.20.3, flux-operator 0.57.0 healthy, cluster reconciling normally. But the policy hole was real: titles like "update cilium chart 1.19→1.20" would have merged Friday at the next release-train window.

### Fix

1. **Line 150:** `grep -qi` → `grep -qiE` — makes `ceph|cilium|flux|dragonfly` work as alternation.

2. **New `needs-review` label gate** (lines 156-161): auto-merge now hard-skips any PR labeled `needs-review` (set correctly by `pr-classify` with a working `-E` regex). This is defense in depth — two independent detection layers must both fail for a critical-infra PR to auto-merge.

3. **AGENTS.md**: Updated the auto-merge policy table ("critical infra" row matches the runtime regex + label gate) and added a defense-in-depth bullet.

### Proof

Before fix — dead filter (no match):
```bash
$ echo "fix(container): update rook-ceph group (v1.20.2 → v1.20.3)" | grep -qi "ceph|cilium|flux|dragonfly"
$ echo $?
1  # no match — would have auto-merged
```

After fix — working:
```bash
$ echo "fix(container): update rook-ceph group (v1.20.2 → v1.20.3)" | grep -qiE "ceph|cilium|flux|dragonfly"
$ echo $?
0  # match — skipped as manual ✓
```

### Blast radius

- `.github/workflows/auto-merge.yaml` — CI-only, no cluster impact
- `AGENTS.md` — docs
- `README.md` — trailing-whitespace cleanup (pre-commit auto-fix)

### ⏰ Deadline

Merge before **Fri Aug 7 ~02:00 UTC** — PR [#3709](https://github.com/axeII/home-ops/pull/3709) (cilium 1.19.6→1.20.0, minor, `risk/critical`) becomes age-eligible then and would auto-merge if the gate is still broken. (PR #3655, ceph v20→v21 major, is blocked by the major rule and safe regardless.)