### PR TITLE
fix(renovate): group docker.io/rook/ceph with rook-ceph updates

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -97,7 +97,7 @@
       description: "Rook-Ceph Group",
       groupName: "rook-ceph",
       matchDatasources: ["docker"],
-      matchPackageNames: ["/rook-ceph/", "/rook-ceph-cluster/"],
+      matchPackageNames: ["/rook-ceph/", "/rook-ceph-cluster/", "/rook\\/ceph/"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },


### PR DESCRIPTION
## Summary
- The `rook-ceph` Renovate group's `matchPackageNames` only matched `rook-ceph` and `rook-ceph-cluster` (dash-separated), so `docker.io/rook/ceph` (slash-separated) fell outside the group.
- This caused the same Rook/Ceph release (e.g. v1.20.3 → v1.20.5) to be split across separate PRs (#3773 and #3774) instead of one grouped PR.
- Added `/rook\/ceph/` to `matchPackageNames` so future coupled bumps land as a single PR.

## Test plan
- [x] Validated with `renovate-config-validator` — config parses and validates successfully.
