### PR TITLE
fix(rook-ceph): raise mgr memory limit to stop OOMKill restarts

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -104,7 +104,7 @@ spec:
       resources:
         mgr:
           limits:
-            memory: 2Gi
+            memory: 4Gi
           requests:
             cpu: 50m
             memory: 512Mi


### PR DESCRIPTION
## Summary
- `rook-ceph-mgr-a-545d799cdb-hgb66` has been `OOMKilled` 51 times against its 2Gi memory limit, roughly once a day recently (last cycle: ~14.6h uptime before OOM).
- `mgr.count` is 1 (no standby mgr-b), so each restart drops the dashboard, `pg_autoscaler`, and balancer module for the ~10-30s the pod takes to come back. Ceph health has stayed `HEALTH_OK` throughout since the mgr is not in the client I/O data path (OSDs/mons handle that independently), but the recurring OOMs point to memory pressure that will likely worsen as the cluster grows.
- Raised `resources.mgr.limits.memory` from 2Gi to 4Gi (matching the existing OSD limit) to give the daemon headroom and stop the kill loop. Left `requests` unchanged so scheduling/bin-packing across the 3 nodes is unaffected.

## Test plan
- [ ] After Flux reconciles, confirm `rook-ceph-mgr-a` restart count stops climbing and no further `OOMKilled` events appear (`kubectl get pod -n rook-ceph rook-ceph-mgr-a-* -o jsonpath='{.status.containerStatuses[?(@.name=="mgr")].restartCount}'`).
- [ ] Confirm `ceph status` / CephCluster stays `HEALTH_OK` post-rollout.
