### PR TITLE
fix(bootstrap): bump Gateway API CRDs to v1.6.1 for Cilium 1.20 compat

### DIFF
--- a/scripts/bootstrap-apps.sh
+++ b/scripts/bootstrap-apps.sh
@@ -92,7 +92,7 @@ function apply_crds() {
         # renovate: datasource=github-releases depName=kubernetes-sigs/external-dns
         https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/tags/v0.18.0/config/crd/standard/dnsendpoints.externaldns.k8s.io.yaml
         # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
-        https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/experimental-install.yaml
+        https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/experimental-install.yaml
         # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator
         https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.84.0/stripped-down-crds.yaml
     )


### PR DESCRIPTION
## Summary
- `grafana.juno.moe` (and, as it turned out, **every** HTTPS route on both the `internal` and `external` Cilium gateways) went down when the `feat(helm): update chart cilium (1.19.6 → 1.20.1)` commit reconciled.
- Root cause: Cilium 1.20's operator does a GatewayAPI dependency check requiring `tlsroutes`, `referencegrants`, and `backendtlspolicies` CRDs to expose a `v1` API version. The cluster had these pinned at the Gateway API `v1.3.0` bundle (only `v1alpha2`/`v1beta1`/`v1alpha3` for those three). The check failed, so `cilium-operator` silently skipped starting the Gateway API secret-sync controller that mirrors the TLS cert `Secret` into the `cilium-secrets` namespace for Envoy's SDS.
- Result: Envoy had no certificate to present on the HTTPS listeners, so **every TLS handshake was reset** (confirmed via `openssl s_client`: ClientHello sent, zero bytes back, connection reset). Plain HTTP on the same gateway worked fine — this was TLS-listener-specific, not a general outage.
- Fix: bump the Gateway API CRD bundle pinned in `scripts/bootstrap-apps.sh` from `v1.3.0` to `v1.6.1` (the version Cilium 1.20's own docs recommend), which provides `v1` for all three CRDs.

## Already applied live
To restore service immediately, I applied the v1.6.1 CRD bundle to the live cluster (`kubectl apply --server-side`) and restarted `cilium-operator` to re-run its dependency check. Confirmed fixed:
- `cilium-secrets` namespace now has the synced TLS secret.
- `https://grafana.juno.moe` returns `200`.
- `external` gateway's HTTPS listener also handshakes successfully again (was resetting the same way).

This PR just brings the repo (and future bootstraps) in line with what's now running.

## Test plan
- [x] `kubectl get secrets -n cilium-secrets` shows the synced TLS secret.
- [x] `curl -k https://grafana.juno.moe` returns 200.
- [x] `openssl s_client` against both gateway IPs completes a TLS handshake (no reset).
- [ ] On next cluster bootstrap from scratch, confirm `apply_crds` pulls the v1.6.1 bundle without issue.
