### PR TITLE
fix(external-secrets): revert chart 2.9.0 -> 2.8.0, onepasswordSDK wasm crash

### DIFF
--- a/kubernetes/apps/kube-system/external-secrets/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: external-secrets
-      version: 2.9.0
+      version: 2.8.0
       sourceRef:
         kind: HelmRepository
         name: external-secrets


### PR DESCRIPTION
## Summary
- Reverts the `external-secrets` HelmRelease chart from `2.9.0` back to `2.8.0` (#3754).
- All 37 `ExternalSecret` resources in the cluster have been failing to sync since 2026-08-16/17 with:
  ```
  could not get secret data from provider: wasm error: out of bounds memory access
  op_extism_core.wasm ... extism_pdk::input_bytes
  ```
- This is the `onepasswordSDK` provider's WASM plugin (extism) crashing on every fetch. The failure timing lines up exactly with #3754 merging on 2026-08-14T05:00:36Z — each `ExternalSecret` started failing on its first refresh after the upgrade (refresh intervals staggered across the day/next day, hence the spread of first-failure timestamps from 2026-08-16 through 2026-08-17).
- Existing target `Secret`s still hold their last-good values (`deletionPolicy: Retain`), so nothing user-facing has broken — but no credential rotation or newly-added `ExternalSecret` will land until this is fixed.
- Pure version pin change, no other config drift between the two versions in this repo's values.

## Test plan
- [ ] After Flux reconciles, confirm `HelmRelease/kube-system/external-secrets` is `Ready` at chart `2.8.0`
- [ ] Confirm previously-failing `ExternalSecret`s (e.g. `flux-system/konflate`, `media/sonarr`, `observability/gatus`) return to `Ready`/`SecretSynced` within their refresh interval (up to 1h)
- [ ] Spot-check one Secret's data actually refreshed (`kubectl get secret -o jsonpath='{.metadata.resourceVersion}'` bumps, or trigger a manual `kubectl annotate externalsecret ... force-sync=$(date +%s)`)