### PR TITLE
fix(rook-ceph): unblock OSD upgrade stuck on cephx key mismatch

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -42,6 +42,11 @@ spec:
     # Route is managed by a separate HTTPRoute (dashboard-proxy) instead of the
     # Helm chart, because Cilium Gateway envoy can't EDS-proxy to hostNetwork pods.
     cephClusterSpec:
+      # Temporary: unblock the OSD image rollout to v20.2.4 while the cluster is
+      # HEALTH_ERR from the CVE-2025-30156 cephx key-type transition (mon/mgr/mds
+      # already on v20.2.4, OSDs stuck on v20.2.2 can't decode the new rotating
+      # keys). Revert to false once all OSDs report v20.2.4 and health clears.
+      continueUpgradeAfterChecksEvenIfNotHealthy: true
       cephConfig:
         global:
           bdev_enable_discard: "true"


### PR DESCRIPTION
## Summary
- mon/mgr/mds are already on v20.2.4 (the CVE-2025-30156 cephx fix); the 3 OSDs are stuck on v20.2.2 and can't decode the new rotating auth keys the upgraded mons issue (`cephx client: could not set rotating key: decode_decrypt failed`).
- This keeps `CephCluster/rook-ceph` in `HEALTH_ERR`, and rook-ceph-operator's own safety gate (`continueUpgradeAfterChecksEvenIfNotHealthy: false`, the default) then refuses to roll the OSD image forward while unhealthy — a deadlock.
- Temporarily flips that gate to `true` so the operator can proceed rolling OSDs to v20.2.4 one at a time despite the ERR status, restoring cephx compatibility. Meant to be reverted back to `false` once all OSDs report v20.2.4 and cluster health clears.

## Test plan
- [ ] Flux reconciles `rook-ceph-cluster` HelmRelease successfully
- [ ] rook-ceph-operator begins rolling `rook-ceph-osd-0/1/2` to `quay.io/ceph/ceph:v20.2.4`
- [ ] Each OSD rejoins as `up`/`in` after its image bump (watch `ceph status` / CephCluster health)
- [ ] `ceph health` returns to `HEALTH_OK` (or just the expected transient `AUTH_INSECURE_*` warnings clear)
- [ ] Revert `continueUpgradeAfterChecksEvenIfNotHealthy` to `false` in a follow-up once healthy

https://claude.ai/code/session_01LYtxJzSoF7Q1okSzi9TbnG