### PR TITLE
fix(rook-ceph): also set skipUpgradeChecks to unblock OSD upgrade

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -45,8 +45,12 @@ spec:
       # Temporary: unblock the OSD image rollout to v20.2.4 while the cluster is
       # HEALTH_ERR from the CVE-2025-30156 cephx key-type transition (mon/mgr/mds
       # already on v20.2.4, OSDs stuck on v20.2.2 can't decode the new rotating
-      # keys). Revert to false once all OSDs report v20.2.4 and health clears.
+      # keys). continueUpgradeAfterChecksEvenIfNotHealthy alone wasn't enough -
+      # the operator's pre-upgrade version check needs skipUpgradeChecks too
+      # ("failed the ceph version check ... refusing to upgrade"). Revert both
+      # to false once all OSDs report v20.2.4 and health clears.
       continueUpgradeAfterChecksEvenIfNotHealthy: true
+      skipUpgradeChecks: true
       cephConfig:
         global:
           bdev_enable_discard: "true"


### PR DESCRIPTION
## Summary
- Follow-up to #3797. `continueUpgradeAfterChecksEvenIfNotHealthy: true` alone did not unblock the OSD image rollout to v20.2.4.
- The operator's actual `Progressing` condition on `CephCluster/rook-ceph` reads: *"failed the ceph version check: ceph status in namespace rook-ceph is not healthy, refusing to upgrade. Either fix the health issue or force an update by setting skipUpgradeChecks to true in the cluster CR"* — a separate pre-upgrade version-check gate.
- Adds `skipUpgradeChecks: true` alongside the existing flag so rook-ceph-operator can proceed rolling `rook-ceph-osd-0/1/2` from v20.2.2 to v20.2.4 despite the current `HEALTH_ERR` (caused by the cephx AES256K key-type mismatch between the already-upgraded mons and the still-v20.2.2 OSDs).

## Test plan
- [ ] Flux reconciles `rook-ceph-cluster` HelmRelease successfully
- [ ] rook-ceph-operator begins rolling `rook-ceph-osd-0/1/2` to `quay.io/ceph/ceph:v20.2.4`
- [ ] Each OSD rejoins as `up`/`in` after its image bump
- [ ] `ceph health` returns to `HEALTH_OK`
- [ ] Revert both `continueUpgradeAfterChecksEvenIfNotHealthy` and `skipUpgradeChecks` to `false` in a follow-up once healthy

https://claude.ai/code/session_01LYtxJzSoF7Q1okSzi9TbnG