### PR TITLE
fix(rook-ceph): revert temporary OSD upgrade-gate flags

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -42,15 +42,6 @@ spec:
     # Route is managed by a separate HTTPRoute (dashboard-proxy) instead of the
     # Helm chart, because Cilium Gateway envoy can't EDS-proxy to hostNetwork pods.
     cephClusterSpec:
-      # Temporary: unblock the OSD image rollout to v20.2.4 while the cluster is
-      # HEALTH_ERR from the CVE-2025-30156 cephx key-type transition (mon/mgr/mds
-      # already on v20.2.4, OSDs stuck on v20.2.2 can't decode the new rotating
-      # keys). continueUpgradeAfterChecksEvenIfNotHealthy alone wasn't enough -
-      # the operator's pre-upgrade version check needs skipUpgradeChecks too
-      # ("failed the ceph version check ... refusing to upgrade"). Revert both
-      # to false once all OSDs report v20.2.4 and health clears.
-      continueUpgradeAfterChecksEvenIfNotHealthy: true
-      skipUpgradeChecks: true
       cephConfig:
         global:
           bdev_enable_discard: "true"


### PR DESCRIPTION
## Summary
- Follow-up cleanup to #3797 and #3798. Both `continueUpgradeAfterChecksEvenIfNotHealthy` and `skipUpgradeChecks` were temporarily set to `true` on `CephCluster/rook-ceph` to unblock the OSD image rollout from v20.2.2 to v20.2.4 (CVE-2025-30156 cephx key-type transition).
- The upgrade has completed: all 9 Ceph daemons (mon/mgr/mds/osd) now report `20.2.4-0 tentacle`, and `PG_DEGRADED` has cleared.
- Removes both flags now that they're no longer needed, restoring the operator's default safety gates for future upgrades.

## Test plan
- [ ] Flux reconciles `rook-ceph-cluster` HelmRelease successfully
- [ ] `CephCluster.spec.continueUpgradeAfterChecksEvenIfNotHealthy` and `.spec.skipUpgradeChecks` both return to `false`
- [ ] Cluster remains healthy after the flags are removed (no unexpected reconcile side effects)

https://claude.ai/code/session_01LYtxJzSoF7Q1okSzi9TbnG