### PR TITLE
fix(rook-ceph): rotate cephx keys to AES256K to clear HEALTH_ERR

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -42,6 +42,15 @@ spec:
     # Route is managed by a separate HTTPRoute (dashboard-proxy) instead of the
     # Helm chart, because Cilium Gateway envoy can't EDS-proxy to hostNetwork pods.
     cephClusterSpec:
+      # All daemons (mon/mgr/mds/osd) now run v20.2.4 and support AES256K cephx
+      # keys (CVE-2025-30156 fix). Rotate off the old insecure AES key type to
+      # clear HEALTH_ERR/AUTH_INSECURE_SERVICE_KEY_TYPE. Bump keyGeneration to
+      # a higher integer to trigger another rotation in the future.
+      security:
+        cephx:
+          daemon:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
       cephConfig:
         global:
           bdev_enable_discard: "true"


### PR DESCRIPTION
## Summary
- Stacked on #3800 (revert the temporary OSD upgrade-gate flags), since this builds on the same file region right after those lines are removed.
- Now that all Ceph daemons run v20.2.4 (CVE-2025-30156 cephx fix), the cluster still reports `HEALTH_ERR` from `AUTH_INSECURE_SERVICE_KEY_TYPE` — mon/mgr/mds/osd all support the new AES256K key type but haven't rotated their existing keys off the old insecure AES type.
- Per [Rook's CephX Key Rotation docs](https://rook.io/docs/rook/latest-release/Storage-Configuration/Advanced/cephx-key-rotation/), rotation is opt-in: setting `security.cephx.daemon.keyRotationPolicy: KeyGeneration` with `keyGeneration` set to an integer higher than the current generation triggers Rook to rotate daemon cephx keys to AES256K. Starting at `keyGeneration: 2` (current/default generation is 1, never rotated).
- Any future rotation just needs `keyGeneration` bumped again to a higher integer.

## Test plan
- [ ] Flux reconciles `rook-ceph-cluster` HelmRelease successfully
- [ ] `CephCluster.status.cephx.*.keyGeneration` fields progress to `2` for mon/mgr/osd/mds
- [ ] `ceph health` clears `AUTH_INSECURE_SERVICE_KEY_TYPE` and related `AUTH_INSECURE_*` warnings, returning to (or close to) `HEALTH_OK`
- [ ] No daemon restarts cause unexpected disruption during rotation (expect brief per-daemon restarts, similar to the OSD image rollout)

https://claude.ai/code/session_01LYtxJzSoF7Q1okSzi9TbnG