### PR TITLE
feat(gatus): add Ceph and Flux health checks via existing metrics endpoints

### DIFF
--- a/kubernetes/apps/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/config.yaml
@@ -45,5 +45,27 @@ endpoints:
     alerts:
       - type: pushover
 
+  - name: ceph-health
+    group: infra
+    url: http://rook-ceph-mgr.rook-ceph.svc.cluster.local:9283/metrics
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY] != pat(*ceph_health_status{* 2*)"
+    alerts:
+      - type: pushover
+        description: "Ceph cluster is in HEALTH_ERR"
+
+  - name: flux-health
+    group: infra
+    url: http://kube-state-metrics.observability.svc.cluster.local:8080/metrics
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY] != pat(*ready=\"False\"*)"
+    alerts:
+      - type: pushover
+        description: "a Flux-managed resource is not Ready"
+
 web:
   port: ${GATUS_WEB_PORT}


### PR DESCRIPTION
## Summary
Right now Gatus only monitors things that have an `HTTPRoute` (auto-discovered by `gatus-sidecar`). That means cluster-internal problems like the rook-ceph cephx incident or a stuck Flux reconciliation never trip an alert, even though they're exactly the kind of thing worth a Pushover ping.

Adds two new endpoints to `gatus-configmap` that poll metrics already scraped in-cluster — no new exporter, no Alertmanager, no webhook bridge (which is the class of thing that silently dropped alerts previously):

- **`ceph-health`** — polls `rook-ceph-mgr.rook-ceph.svc.cluster.local:9283/metrics` directly and alerts only when `ceph_health_status == 2` (HEALTH_ERR). Deliberately ignores `1` (HEALTH_WARN) so it stays quiet through known-benign residual warnings (e.g. `AUTH_INSECURE_CLIENT_KEY_TYPE`) instead of paging on noise.
- **`flux-health`** — polls `kube-state-metrics.observability.svc.cluster.local:8080/metrics` and alerts if *any* Flux-managed Kustomization/HelmRelease reports `ready="False"` (via the `gotk_resource_info` metric kube-state-metrics already exports for all ~67 Flux resources).

Both use Gatus's own native Pushover alerting (same `default-alert` thresholds — 3 failures to trigger, 3 successes to resolve), reusing the credentials already wired up for the existing `blog` endpoint.

## Test plan
- [ ] Confirm Flux reconciles the `gatus` Kustomization and the ConfigMap picks up the new endpoints (reloader should restart the pod)
- [ ] Confirm both endpoints show up healthy on the Gatus UI / `status.juno.moe`
- [ ] Optionally force-test by checking `ceph_health_status` is currently `1` (WARN) and confirming no alert fires (as designed)
