### PR TITLE
fix(coredns): block AAAA responses to stop IPv6-unreachable dials

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helm/values.yaml
@@ -28,6 +28,10 @@ servers:
           fallthrough in-addr.arpa ip6.arpa
       - name: autopath
         parameters: "@kubernetes"
+      - name: template
+        parameters: ANY AAAA
+        configBlock: |-
+          rcode NXDOMAIN
       - name: forward
         parameters: . /etc/resolv.conf
       - name: cache


### PR DESCRIPTION
## What

Block AAAA (IPv6) DNS answers cluster-wide in CoreDNS by adding a `template` plugin returning NXDOMAIN for AAAA queries, placed after `kubernetes`/`autopath` (so in-cluster/pod DNS is untouched) and before `forward`.

## Why

The cluster is IPv4-only (Talos podCIDR `10.42.0.0/16`, no IPv6 anywhere in `talconfig.yaml`), but CoreDNS forwards straight to the node's upstream resolver with no AAAA filtering. External dual-stack hosts (e.g. `raw.githubusercontent.com`, Fastly-backed) can hand back an AAAA record; pods then try to dial an IPv6 address and fail with `network is unreachable` since there's no real IPv6 route anywhere in the network.

This has been surfacing as:
- `flux-system/cluster-apps` Kustomization reconcile failures when building the tree, because `kubernetes/apps/database/dragonfly/app/kustomization.yaml` fetches the dragonfly-operator CRD live from `raw.githubusercontent.com` on every `kustomize build`. A single IPv6 flake there fails the *whole* apps tree for that reconcile, cascading into unrelated "dependencies failed" errors (e.g. `observability/gatus`).
- Konflate (in-cluster PR render/status service) renders the same tree with `kustomize build`, so the same transient flake produces false-negative render failures / status checks on unrelated open PRs.

Blocking AAAA at the resolver removes the whole class of failure — Go's dialer will only ever get an A record and go straight to IPv4, cluster-wide, for any pod/controller, not just this one CRD fetch.

## Verification

- `just flate-test`: `kube-system/coredns` Kustomization renders (✓). The HelmRelease/OCIRepository verification steps fail in this sandbox with `ghcr.io ... 403 denied` — a pre-existing environment/registry-auth limitation affecting every chart in the repo identically, unrelated to this change.
- `pre-commit run --files kubernetes/apps/kube-system/coredns/app/helm/values.yaml`: all hooks pass.
- `python3 scripts/find_mistakes.py`: no new warnings (pre-existing, unrelated warnings only).

## Risk

Low. This only suppresses AAAA answers — nothing in the cluster currently uses IPv6 (no dual-stack config anywhere in Talos/Cilium), so there is no existing IPv6 traffic path to break. CoreDNS reloads on ConfigMap change via the standard `reload` plugin.