### PR TITLE
fix(coredns): return NOERROR instead of NXDOMAIN for blocked AAAA queries

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helm/values.yaml
@@ -31,7 +31,7 @@ servers:
       - name: template
         parameters: ANY AAAA
         configBlock: |-
-          rcode NXDOMAIN
+          rcode NOERROR
       - name: forward
         parameters: . /etc/resolv.conf
       - name: cache


### PR DESCRIPTION
## What

Changes the AAAA-blocking `template` plugin added in #3804 from `rcode NXDOMAIN` to `rcode NOERROR`.

## Why

Incident: shortly after #3804 merged, `radarr`, `sonarr`, and `prowlarr` all went into CrashLoopBackOff (`media` namespace). Root cause traced via pod logs:

```
System.Net.Sockets.SocketException (00000005, 0xFFFDFFFF): Name does not resolve
   at Npgsql.Internal.NpgsqlConnector.Connect(...)
```

All three connect to an external Postgres at `db.internal` (defined in `externalsecret.yaml`, not a cluster-local name). `db.internal` has a valid A record but no AAAA record. `NXDOMAIN` on the AAAA query asserts the name **does not exist at all** — which is inconsistent with the A record existing for the same name. .NET's DNS resolution path (used by Npgsql/Radarr/Sonarr/Prowlarr) treats an NXDOMAIN response as "this name is dead" and aborts the whole lookup, discarding the valid A answer, rather than falling back to it. A manual test confirmed this: `nslookup` (BusyBox, more lenient) resolved the A record fine despite the AAAA NXDOMAIN, but the .NET apps still failed hard.

`NOERROR` with an empty answer section is the semantically correct response for "this name exists, it just has no AAAA record" — it's what a real authoritative server would return for an IPv4-only host, and it does not tell resolvers the name is invalid. This preserves the original goal (never handing out an unreachable IPv6 address) without the false "name doesn't exist" signal that broke external-name resolution for any client with strict getaddrinfo-style dual-stack handling.

## Verification

- `just flate-test`: `kube-system/coredns` Kustomization renders clean.
- Manually reproduced and confirmed the failure mode against the live cluster: `nslookup -type=aaaa db.internal` under the previous config returned `NXDOMAIN`, while the A record resolved fine — consistent with the app-level "Name does not resolve" exception.
- `pre-commit run` on the changed file: all hooks pass.

## Risk

Low, and directionally safer than the previous config — no client-visible IPv6 addresses are handed out either way, but this stops CoreDNS from lying about a name's existence. Restores `radarr`/`sonarr`/`prowlarr` DB connectivity once merged and reconciled.