### PR TITLE
fix(external-secrets): lower refresh rate to avoid 1Password rate limiting

### DIFF
--- a/kubernetes/apps/database/pgbackup/app/externalsecret.yaml
+++ b/kubernetes/apps/database/pgbackup/app/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: pgbackup
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/default/affine/app/externalsecret.yaml
+++ b/kubernetes/apps/default/affine/app/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: affine
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/default/atuin/app/externalsecret.yaml
+++ b/kubernetes/apps/default/atuin/app/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: atuin
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/default/docmost/app/externalsecret.yaml
+++ b/kubernetes/apps/default/docmost/app/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: docmost
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/default/home-assistant/app/externalsecret.yaml
+++ b/kubernetes/apps/default/home-assistant/app/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: home-assistant
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/default/karakeep/app/externalsecret.yaml
+++ b/kubernetes/apps/default/karakeep/app/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: karakeep
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/default/minecraft/app/externalsecret.yaml
+++ b/kubernetes/apps/default/minecraft/app/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: &name minecraft-secret
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/default/paperless/app/externalsecret.yaml
+++ b/kubernetes/apps/default/paperless/app/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: paperless
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: github-webhook-token
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: konflate
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/media/prowlarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/prowlarr/app/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: prowlarr
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/media/radarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/radarr/app/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: radarr
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/media/recyclarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/recyclarr/app/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: recyclarr
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/media/sabnzbd/app/externalsecret.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: sabnzbd
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/media/seerr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/seerr/app/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: seerr
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/media/sonarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/sonarr/app/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: sonarr
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/media/unpackerr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/unpackerr/app/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: unpackerr
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/network/cloudflare-tunnel/app/externalsecret.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: cloudflared
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/network/external-dns/cloudflare/externalsecret.yaml
+++ b/kubernetes/apps/network/external-dns/cloudflare/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: external-dns-cloudflare
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/network/external-dns/unifi/externalsecret.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: external-dns-unifi
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/observability/gatus/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/gatus/app/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: gatus
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/observability/grafana-cloud/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana-cloud/app/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: grafana-cloud
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/observability/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/app/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: grafana-admin-password
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/observability/unpoller/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/unpoller/app/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: unpoller
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/externalsecret.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/externalsecret.yaml
@@ -4,7 +4,7 @@ kind: ExternalSecret
 metadata:
   name: grafana-cloud
 spec:
-  refreshInterval: 1h
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/system-upgrade/app/externalsecret.yaml
+++ b/kubernetes/apps/system-upgrade/app/externalsecret.yaml
@@ -4,6 +4,7 @@ kind: ExternalSecret
 metadata:
   name: tuppr
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/volsync-system/kopia/app/externalsecret.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: kopia
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/apps/volsync-system/volsync/maintenance/externalsecret.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: volsync-maintenance
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect

--- a/kubernetes/components/volsync/externalsecret.yaml
+++ b/kubernetes/components/volsync/externalsecret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: "${APP}-volsync"
 spec:
+  refreshInterval: 4h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect


### PR DESCRIPTION
## Problem

Flux Kustomization health checks were failing for `home-assistant`, `plex`, and `external-dns-unifi` (`HealthCheckFailed`, timing out waiting on `ExternalSecret` status). Root cause traced to the `external-secrets` controller logging `rate limit exceeded` errors from the 1Password Connect/SDK provider across dozens of ExternalSecrets cluster-wide.

28 of 29 `ExternalSecret` manifests had no explicit `refreshInterval`, defaulting to the CRD's 1h, so nearly everything reconciles on the same ~1h cadence and bursts requests against 1Password together.

## Fix

Set `spec.refreshInterval: 4h` explicitly on all 29 `ExternalSecret` manifests (including the shared `kubernetes/components/volsync/externalsecret.yaml` component used by ~12 apps), quartering request volume against 1Password.

## Test plan

- [x] YAML validated to parse correctly with exactly one `refreshInterval: 4h` per file
- [x] `pre-commit run` passes (yamllint, secret detection, etc.)
- [ ] Confirm `external-secrets` controller logs clear of `rate limit exceeded` after rollout
- [ ] Confirm the three affected Flux Kustomizations reconcile healthy