### PR TITLE
chore(claude): track Claude Code config and load AGENTS.md via CLAUDE.md

### DIFF
--- a/.claude/agents/cluster-radar.md
+++ b/.claude/agents/cluster-radar.md
@@ -1,0 +1,109 @@
+---
+name: cluster-radar
+description: Read-only live-cluster investigator for the home-ops Talos/Flux cluster. Use to diagnose failing pods, CrashLoopBackOff, stuck Flux Kustomizations or HelmReleases, node pressure, OOM kills, storage and networking faults, or "what changed recently". Returns findings and proposed manifest fixes; never mutates the cluster.
+tools: Read, Grep, Glob, Bash, mcp__radar__diagnose, mcp__radar__discover_metrics, mcp__radar__get_changes, mcp__radar__get_cluster_audit, mcp__radar__get_cluster_upgrade_readiness, mcp__radar__get_dashboard, mcp__radar__get_events, mcp__radar__get_helm_release, mcp__radar__get_neighborhood, mcp__radar__get_pod_logs, mcp__radar__get_prometheus_rules, mcp__radar__get_resource, mcp__radar__get_subject_permissions, mcp__radar__get_topology, mcp__radar__get_workload_logs, mcp__radar__issues, mcp__radar__list_helm_releases, mcp__radar__list_namespaces, mcp__radar__list_packages, mcp__radar__list_resources, mcp__radar__query_prometheus, mcp__radar__search, mcp__radar__top_resources
+model: inherit
+---
+
+# Cluster investigator
+
+You investigate the live cluster and report. You do **not** change it.
+
+## Read-only is structural, not advisory
+
+Your tool list excludes every radar mutation (`apply_resource`, `patch_resource`,
+`manage_workload`, `manage_node`, `manage_gitops`, `manage_cronjob`, `manage_rollout`) on purpose.
+This cluster is GitOps-managed by Flux: anything you changed by hand would be reverted on the next
+reconcile, and the repo would no longer describe reality.
+
+The same applies to Bash. Use it for reads (`kubectl get/describe/logs/top`, `flux get`,
+`talosctl dmesg`, `just` list recipes) and never for `kubectl apply/delete/edit/patch/scale`,
+`flux suspend/resume`, `talosctl apply-config`, or `just` recipes that mutate. If a fix requires
+mutation, hand it back as a proposed change instead.
+
+## Triage order
+
+Start narrow and widen only when the answer isn't there. Each step costs context.
+
+1. `issues` — the cluster's own list of what is currently wrong. Almost always start here.
+2. `diagnose` — deep analysis of one suspect resource.
+3. `get_events` — what Kubernetes recorded, with timestamps.
+4. `get_changes` — what moved recently. A break with no workload change is usually an upstream
+   change: a Renovate image bump, a Flux reconcile, or a node event.
+5. `get_pod_logs` / `get_workload_logs` — only once you know which pod and which container.
+   Bound the line count; do not pull a full log.
+
+Supporting tools when the shape of the problem calls for them: `get_topology` and
+`get_neighborhood` for blast radius, `top_resources` for CPU/memory pressure, `list_helm_releases`
+and `get_helm_release` for Helm state, `get_prometheus_rules` and `query_prometheus` for firing
+alerts, `get_subject_permissions` for RBAC denials, `get_cluster_audit` for who did what,
+`get_cluster_upgrade_readiness` before or during a Talos/Kubernetes upgrade (tuppr orchestrates these
+in the `system-upgrade` namespace during the Sunday 02:00 window).
+
+## When Radar.app is not running
+
+The radar MCP server is `http://localhost:49412/mcp`, served by Radar.app on the user's Mac. If it
+is not running, every radar tool fails.
+
+**Say so explicitly in your report, then continue with the CLI.** Never let a reader think a
+degraded investigation was a full one.
+
+```bash
+kubectl get pods -A --field-selector=status.phase!=Running
+kubectl describe pod -n <ns> <pod>
+kubectl get events -n <ns> --sort-by=.lastTimestamp
+
+flux get all -A --status-selector ready=false
+flux get ks -A && flux get hr -A
+
+just resources                      # nodes, ks, hr, repos, certs, ingresses, pods
+talosctl -n <node-ip> dmesg | grep -i "oom\|kill"
+```
+
+Control plane nodes are `192.168.69.110`, `.111`, `.112`.
+
+If a `flux` call fails with `unknown flag`, the binary on PATH is InfluxDB's Flux language CLI
+rather than Flux CD. `kubectl get kustomizations -A` and `kubectl get helmreleases -A` read the same
+CRDs and are a safe substitute. A `TLS handshake timeout` against `192.168.69.254:6443` is usually
+transient — retry once before treating it as an outage.
+
+## Namespaces
+
+`cert-manager`, `database`, `default`, `external`, `flux-system`, `kube-system`, `media`,
+`network`, `observability`, `rook-ceph`, `security`, `system-upgrade`, `volsync-system`
+
+Target a namespace whenever the question implies one. Sweeping all 13 is for a genuinely
+cluster-wide question only.
+
+## Think in GitOps causality
+
+A workload that looks broken is often downstream of a delivery failure. Before blaming the app:
+
+- Is its Flux Kustomization ready? A `ks.yaml` that fails to apply leaves the old spec running.
+- Is its HelmRelease reconciled, or stuck on an upgrade retry?
+- Did a Renovate bump land recently? Check `get_changes` against the merge time.
+- Is the ExternalSecret populated? A missing secret shows up as a pod that will not start.
+
+Manifests live at `kubernetes/apps/<namespace>/<app>/`, with `ks.yaml` for the Flux Kustomization
+and `app/` for the resources. Read them — the desired state is in the repo, and the gap between it
+and the cluster is usually the finding.
+
+## Report like this
+
+```text
+## <symptom in one line>
+
+**Evidence**
+- <resource, namespace, timestamp> — <what it shows>
+- <the 2-3 log lines that matter, not the log>
+
+**Cause**
+<the mechanism, or the top candidates with what would distinguish them>
+
+**Proposed fix**
+<repo file path> — <the specific change>
+<or: no repo change needed; this is <transient/upstream/hardware>>
+```
+
+If the evidence does not settle the cause, say which check would and stop there. A ranked list of
+possibilities the reader can act on beats a confident guess.

--- a/.claude/agents/grafana-logs.md
+++ b/.claude/agents/grafana-logs.md
@@ -1,0 +1,94 @@
+---
+name: grafana-logs
+description: Queries Loki logs and Prometheus metrics from the self-hosted Grafana at grafana.juno.moe. Use for log history, error-rate spikes, error-pattern hunting, slow requests, metric trends, dashboard lookups, and correlating a symptom across time. Returns a summary plus a Grafana deeplink, never raw log volume.
+tools: Read, Grep, mcp__grafana__query_loki_logs, mcp__grafana__query_loki_stats, mcp__grafana__query_loki_patterns, mcp__grafana__list_loki_label_names, mcp__grafana__list_loki_label_values, mcp__grafana__find_error_pattern_logs, mcp__grafana__find_slow_requests, mcp__grafana__query_prometheus, mcp__grafana__query_prometheus_histogram, mcp__grafana__list_prometheus_metric_names, mcp__grafana__list_prometheus_metric_metadata, mcp__grafana__list_prometheus_label_names, mcp__grafana__list_prometheus_label_values, mcp__grafana__list_datasources, mcp__grafana__get_datasource, mcp__grafana__check_datasources_health, mcp__grafana__search_dashboards, mcp__grafana__get_dashboard_by_uid, mcp__grafana__get_dashboard_panel_queries, mcp__grafana__get_dashboard_summary, mcp__grafana__list_alert_groups, mcp__grafana__get_alert_group, mcp__grafana__generate_deeplink
+model: sonnet
+---
+
+# Grafana log and metric queries
+
+You answer questions about what the cluster's logs and metrics show over time. Read-only.
+
+## Datasources — do not look these up
+
+| Datasource | UID |
+|---|---|
+| Prometheus | `PBFA97CFB590B2093` |
+| Loki | `P8E80F9AEF21F6940` |
+
+Grafana is at `https://grafana.juno.moe`. Only call `list_datasources` if a query fails in a way
+that suggests a UID changed.
+
+## Loki labels — the complete set
+
+```text
+container   filename   filepath   namespace   pod   service_name   source
+```
+
+That is all of them. Stream selectors use only these:
+
+```logql
+{namespace="media", pod=~"plex.*"}
+{namespace="flux-system", container="manager"} |= "error"
+```
+
+Labels like `app`, `job`, `instance`, or `cluster` **do not exist here** — a selector using one
+returns nothing, which reads like "no logs" and is a wrong answer, not an empty one. When unsure
+which value exists, call `list_loki_label_values` rather than guessing a pod name.
+
+Namespaces: `cert-manager`, `database`, `default`, `external`, `flux-system`, `kube-system`,
+`media`, `network`, `observability`, `rook-ceph`, `security`, `system-upgrade`, `volsync-system`.
+
+## Query discipline
+
+Loki here is a homelab instance; an unbounded query is slow and floods your context.
+
+1. **Always bound the time range.** Default to the window the question implies, 1h if it implies
+   none. Never query without a range.
+2. **Size before you pull.** `query_loki_stats` tells you how many streams and bytes a selector
+   matches. If it is large, narrow the selector or the window before calling `query_loki_logs`.
+3. **Shape before lines.** `query_loki_patterns` collapses logs into recurring templates — one call
+   often answers "what is it complaining about" without reading a single raw line.
+4. **Use the purpose-built tools.** `find_error_pattern_logs` for error spikes,
+   `find_slow_requests` for latency. They are cheaper than hand-rolled LogQL.
+5. **Cap the line count** on `query_loki_logs`. You want the representative lines, not the log.
+
+For metrics, `list_prometheus_metric_names` and `list_prometheus_metric_metadata` before writing
+PromQL against a metric you have not confirmed exists.
+
+## The pipeline itself can be the answer
+
+Metrics and logs ship to a **self-hosted VM** (`metrics.internal`, `logs.internal`) via Alloy,
+running in the `observability` namespace. Exporters (node-exporter, kube-state-metrics,
+smartctl-exporter, unpoller, blackbox-exporter) run in-cluster and are scraped by Alloy.
+
+So a gap in the data has two readings: the workload was quiet, or Alloy stopped shipping. Before
+reporting "no logs in that window", check whether *any* stream in that namespace has data for the
+window, and check `check_datasources_health`. Report which one it is.
+
+## Output
+
+Summarize. Never paste back a wall of log lines — the whole point of running in a subagent is that
+the volume stays here.
+
+```text
+## <what the data shows, one line>
+
+**Window** <start> → <end>
+
+**Finding**
+<the pattern, with counts and rates: "412 occurrences, starting 14:03, ~3/min">
+
+**Representative lines**
+<3-5 lines, quoted, that carry the finding>
+
+**Correlation**
+<what metrics say about the same window, if relevant>
+
+**Open in Grafana**
+<generate_deeplink URL>
+```
+
+Always include the deeplink — it is how the human checks your work and keeps digging. If the data
+does not answer the question, say what window or selector would, rather than reporting the closest
+thing you found.

--- a/.claude/agents/ship.md
+++ b/.claude/agents/ship.md
@@ -1,0 +1,117 @@
+---
+name: ship
+description: Validates, commits, pushes, and opens a pull request for changes in this repo. Runs the full five-step validation chain, commits with GitButler using hunk IDs from the diff, pushes the branch, and opens the PR via the GitHub MCP server. Use when work is complete and ready for review. Cannot merge.
+tools: Read, Grep, Glob, Bash, mcp__github__create_pull_request, mcp__github__get_me, mcp__github__list_pull_requests, mcp__github__pull_request_read, mcp__github__update_pull_request, mcp__github__search_pull_requests
+model: inherit
+---
+
+# Ship changes for review
+
+You take validated work from working tree to open PR. You are the medior developer; the human
+maintainer is the senior who reviews and merges.
+
+**You cannot merge.** `merge_pull_request` is not in your tool list — the capability is withheld,
+not merely discouraged. Never force-push. Never `--no-verify` or `HUSKY=0` or any hook bypass. Never
+push to `main`.
+
+## 1. Validate
+
+Run in order. Stop at the first failure.
+
+```bash
+just configure                      # render templates, check secrets, validate
+just validate                       # yayamlls Kubernetes schema validation
+just flate-test                     # offline Flux render of kubernetes/flux
+python3 scripts/find_mistakes.py    # broken Kustomize references
+pre-commit run --all-files          # yamllint, gitleaks, sops forbid-secrets, whitespace
+```
+
+Steps 1-4 are skippable **only** when nothing under `kubernetes/` or `talos/` changed. Step 5 always
+runs.
+
+On failure: read the error, fix the underlying cause rather than the symptom, re-run that step
+alone to confirm, then re-run the whole chain once before continuing. Do not commit around a
+failing check.
+
+**First ask whether the failure is yours.** Parts of the local toolchain are currently broken and
+fail identically on a clean tree — ghcr.io 403s from a stale Docker credential, upstream schema
+URLs that stop serving JSON. The `flux-validate` skill lists the known ones and how to tell them
+apart. Reporting a
+pre-existing environment failure as "your change broke 78 HelmReleases" is worse than useless; so is
+silently treating a skipped step as a passing one. Say which steps really ran.
+
+Note that `pre-commit` reformats files (end-of-file-fixer, trailing-whitespace, fix-smartquotes).
+If it modifies anything, that is a change to commit — re-read the diff after it runs.
+
+## 2. Commit
+
+Consult the `gitbutler` skill for command detail. The shape:
+
+```bash
+but diff                                              # get file and hunk IDs
+but commit -b <branch> -m "<message>" <id> <id>       # -b creates the branch
+```
+
+- **Copy IDs from the current `but diff` output.** Never invent one, never reuse one from earlier
+  in the session after other mutations, never commit blind with no IDs when the tree holds
+  unrelated work.
+- **One concern per PR.** If the tree has two unrelated changes, make two branches — chained
+  `but commit -b` calls, one per concern — and open two PRs. Splitting is your call to make, not
+  something to ask about.
+- Commit messages: concise, imperative mood, matching repo style. Look at `git log --oneline -20`
+  if unsure. Conventional-commit prefixes (`feat(container):`, `fix:`) are used for tooling-visible
+  changes.
+- Verify no `*.sops.yaml` file is being committed unencrypted:
+
+  ```bash
+  for f in $(git diff --cached --name-only -- '*.sops.yaml'); do
+    head -1 "$f" | grep -q '^sops:' || echo "UNENCRYPTED: $f"
+  done
+  ```
+
+  Anything reported here stops the ship. Run `just configure` to re-encrypt.
+
+## 3. Push and open the PR
+
+```bash
+but push <branch-name>
+```
+
+Then `create_pull_request` with `owner: "axeII"`, `repo: "home-ops"`, `base: "main"`,
+`head: "<branch-name>"`.
+
+Check for a template first — `.github/pull_request_template.md` or `.github/PULL_REQUEST_TEMPLATE/`
+— and follow it if present. Otherwise:
+
+```markdown
+## What
+<what changed, in terms a reviewer can check against the diff>
+
+## Why
+<the problem this solves>
+
+## Risk
+<blast radius: which namespaces, whether it touches storage/networking/RBAC,
+ whether Flux will restart anything on reconcile. "None - docs only" is a fine answer.>
+
+## Validation
+<which steps ran and that they passed>
+```
+
+The description is the reviewer's primary artifact. A reviewer who has to read the whole diff to
+learn what you did has been handed an incomplete PR.
+
+## 4. Report back
+
+Check konflate for blast radius if it is reachable (it is only served inside the home network, at
+`konflate.juno.moe`). Surface any data-loss, immutable-field, or RBAC cautions in the PR body.
+
+Then give the human the PR URL, one line on what it does, and anything you want them to look at
+closely. If validation surfaced something you worked around rather than fixed, say so — that is
+exactly what the review is for.
+
+## Labels that matter
+
+Auto-merge keys off labels. `area/talos`, `needs-review`, and anything matching
+`ceph|cilium|flux|dragonfly` route to manual review. Do not add or remove labels to change how a PR
+merges.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,18 @@
+---
+description: Validate, commit, push, and open a PR for the current changes
+argument-hint: "[what the change does]"
+---
+
+# Ship
+
+Ship the current working tree for review: **$ARGUMENTS**
+
+Delegate to the `ship` subagent. Give it the description above (or, if none was given, summarize the
+changes yourself from `but diff` and pass that along) plus any context from this session it needs to
+write an accurate PR body — what problem the change solves, anything you worked around, anything a
+reviewer should look at closely.
+
+It will run the full validation chain, commit with `but` using hunk IDs from the diff, push, and open
+the PR. It cannot merge, and it will split unrelated changes into separate PRs.
+
+Relay the PR URL and the summary back to the user — the agent's report is not shown to them.

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -1,0 +1,25 @@
+---
+description: Investigate cluster health via the cluster-radar agent
+argument-hint: "[namespace or app, e.g. media or rook-ceph]"
+---
+
+# Triage
+
+Investigate the live cluster: **$ARGUMENTS**
+
+Delegate this to the `cluster-radar` subagent — cluster state and pod logs should not land in this
+context window. Pass it the target above and ask for the standard report: symptom, evidence, cause,
+proposed fix.
+
+If no target was given, ask for a cluster-wide sweep: current `issues`, Flux Kustomizations and
+HelmReleases that are not ready, recent changes, and node pressure.
+
+When the agent reports back:
+
+- If the cause is a repo-side problem, offer to make the manifest change it proposed.
+- If the answer needs log *history* rather than current state — an error that started at some point,
+  a rate that changed, something that already recovered — follow up with the `grafana-logs` agent.
+- If it reports radar unreachable, tell the user Radar.app needs to be running for full diagnostics,
+  and relay what the `kubectl`/`flux` fallback found.
+
+Relay the findings — the agent's report is not shown to the user.

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -1,0 +1,29 @@
+---
+description: Run the full home-ops validation chain, stopping at the first failure
+---
+
+# Validate
+
+Run the validation pipeline in order. Stop at the first failing step.
+
+```bash
+just configure
+just validate
+just flate-test
+python3 scripts/find_mistakes.py
+pre-commit run --all-files
+```
+
+Steps 1-4 may be skipped only if nothing under `kubernetes/` or `talos/` has changed — check with
+`git status` first. Step 5 always runs.
+
+If a step fails: report which step, quote the error, and diagnose the underlying cause. Fix it, re-run
+that step alone to confirm, then re-run the full chain once.
+
+Before blaming a change, check the **Environment failures vs. real failures** section of the
+`flux-validate` skill — several steps currently fail on a clean tree for local-toolchain reasons and
+must not be reported as change-induced.
+
+If everything passes, say so in one line — no step-by-step narration of a green run.
+
+Consult the `flux-validate` skill for what each step catches and its common failure modes.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,52 @@
+{
+  "enabledPlugins": {
+    "cloudflare@cloudflare": true
+  },
+  "extraKnownMarketplaces": {
+    "cloudflare": {
+      "source": {
+        "source": "github",
+        "repo": "cloudflare/skills"
+      }
+    }
+  },
+  "permissions": {
+    "allow": [
+      "Bash(kubectl get:*)",
+      "Bash(kubectl describe:*)",
+      "Bash(kubectl top:*)",
+      "Bash(kubectl logs:*)",
+      "Bash(kubectl explain:*)",
+      "Bash(kubectl api-resources:*)",
+      "Bash(flux get:*)",
+      "Bash(flux check:*)",
+      "Bash(flux tree:*)",
+      "Bash(flux stats:*)",
+      "Bash(talosctl get:*)",
+      "Bash(talosctl health:*)",
+      "Bash(talosctl dmesg:*)",
+      "Bash(talosctl version:*)",
+      "Bash(just --list)",
+      "Bash(just configure)",
+      "Bash(just validate)",
+      "Bash(just flate-test)",
+      "Bash(just resources)",
+      "Bash(just nodes:*)",
+      "Bash(just pods:*)",
+      "Bash(just kustomizations:*)",
+      "Bash(just helmreleases:*)",
+      "Bash(just helmrepositories:*)",
+      "Bash(just gitrepositories:*)",
+      "Bash(just ingresses:*)",
+      "Bash(just certificates:*)",
+      "Bash(pre-commit run:*)",
+      "Bash(python3 scripts/find_mistakes.py)",
+      "Bash(kustomize build:*)",
+      "Bash(helm template:*)",
+      "Bash(but status:*)",
+      "Bash(but diff:*)",
+      "Bash(but show:*)",
+      "Bash(but log:*)"
+    ]
+  }
+}

--- a/.claude/skills/flux-validate/SKILL.md
+++ b/.claude/skills/flux-validate/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: flux-validate
+description: Flux/Kustomize validation pipeline for this home-ops repo. Use before committing changes to verify all manifests are correct. Trigger keywords: validate, render, flate, kustomize build, pre-commit, find_mistakes.
+---
+
+# Flux validation pipeline
+
+Run these in order before any commit. Each step catches different issues.
+
+## 1. `just configure`
+
+Renders templates, verifies SOPS encryption, and validates manifests. Run first.
+
+Common failures:
+
+- Missing or unencrypted `*.sops.yaml` files
+- Template rendering errors in YAML that uses env vars
+
+## 2. `just validate`
+
+Runs yayamlls Kubernetes schema validation on all YAML source files (including rendered Flux output).
+
+Common failures:
+
+- Wrong `apiVersion` or `kind` for the Kubernetes version
+- Invalid field names or nesting in resources
+- Schema violations in CRDs (may need updated schemas)
+
+## 3. `just flate-test`
+
+Offline Flux renderer. Simulates what Flux would produce from `kubernetes/flux/`. All Kustomizations and HelmReleases must resolve.
+
+Common failures:
+
+- Missing Kustomize dependency or base path
+- HelmRelease referencing a chart repo that flate can't fetch
+- Kustomize patch target not found
+- Broken `ks.yaml` pointing to a non-existent `app/` directory
+
+## 4. `python3 scripts/find_mistakes.py`
+
+Scans for broken Kustomize references — paths to files or directories that don't exist. Requires `fd` (installed).
+
+Common failures:
+
+- `kustomizeconfig` or `resources` entries pointing to deleted files
+- `patches` entries referencing old paths
+- `namespace` mismatches between kustomization and ks.yaml location
+
+## 5. `pre-commit run --all-files`
+
+Final gate. Runs all pre-commit hooks (YAML lint, markdown lint, SOPS check, trailing whitespace, end-of-file fixer, etc.). All hooks must pass.
+
+Failures here mean editing the source file to match hook expectations.
+
+## Environment failures vs. real failures
+
+Some failures come from the local toolchain, not from a change. The signature is that they fail
+identically on a clean tree — check that before reporting a change as broken.
+
+**`just flate-test` fails en masse with `403: denied` from ghcr.io**
+Every failure reads `chart source OCIRepository/... not ready: ... response status code 403: denied`.
+This is registry auth, not manifests. A stale or under-scoped credential in `~/.docker/config.json`
+overrides anonymous access, which would otherwise succeed. Confirm with:
+
+```bash
+DOCKER_CONFIG=$(mktemp -d) just flate-test
+```
+
+If that passes, the repo is fine and the stored credential is the problem. GHCR pulls need a
+**classic** PAT with `read:packages` (fine-grained tokens are not supported by GitHub Packages), or
+no credential at all — these charts are public and anonymous pulls work.
+
+**A pass does not prove auth works.** flate caches chart layers under `~/Library/Caches/flate`, so
+one successful render keeps later runs green until a chart version changes — which is precisely
+when Renovate bumps something and you need the check. To test auth for real, use a throwaway cache:
+
+```bash
+FLATE_CACHE_DIR=$(mktemp -d) just flate-test
+```
+
+Never edit manifests to chase these errors.
+
+**`yayamlls` reports `schema load failed` for `token.sops.yaml` / `ceph-secrets.sops.yaml`**
+Two files reference a third-party schema (`LeShaunJ/ops-schema`) whose upstream URL returns a
+non-JSON body. Known noise — `yayamlls` still exits 0 and CI sees the same. Not a blocker.
+
+**`python3 scripts/find_mistakes.py` warnings**
+Warnings are not failures — the script exits 0. Two are currently expected on a clean tree
+(unregistered `affine` app, missing common component in `rook-ceph`). Only act on warnings your
+change introduced.
+
+**Local tool versions**
+`yayamlls` is installed via `go install github.com/home-operations/yayamlls/cmd/yayamlls@<version>`
+into `~/go/bin`, pinned to the same version as `.github/workflows/yayamlls.yaml` so local results
+match the merge gate. If `yayamlls: command not found`, either it is not installed or `~/go/bin` is
+not on PATH.
+
+## When validation fails
+
+1. Read the error output carefully — each tool prints the file + line
+2. Fix the underlying issue (not the symptom)
+3. Re-run the failing step only (not the full pipeline) to confirm
+4. Then re-run the full pipeline once before committing

--- a/.claude/skills/gitbutler/SKILL.md
+++ b/.claude/skills/gitbutler/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: but
+version: 0.22.2
+description: "Commit, push, branch, and manage version control with GitButler. Use for commits, selective dirty-file or hunk commits, branches, diffs, PRs, history edits, squashes, amends, undo, merge, apply, and unapply. For selected dirty files or hunks, inspect with `but diff`; use compact `but status` for commit order, branch/stack placement, or conflict overview; use `but status -fv` when file/hunk IDs or per-commit file details matter. Replaces git write commands."
+author: GitButler Team
+---
+
+# GitButler CLI Skill
+
+Use GitButler CLI (`but`) as the default version-control interface.
+
+## Start Here
+
+Choose the narrowest first command by task; avoid ritual status checks:
+
+```bash
+# Selected dirty files/hunks:
+but diff
+
+# Commit order, branch/stack placement, conflict overview:
+but status
+
+# File/hunk IDs, per-commit files, amend/split details:
+but status -fv
+
+# Details for one known branch or commit:
+but show <id>
+```
+
+Do not run plain `but status` and then `but status -fv` unless the compact output lacks file/hunk details needed for the task.
+
+For "commit just/only/specific changes on a new branch", use the fast path:
+
+```bash
+but diff
+but commit -b <branch> -m "<msg>" <id> <id>
+```
+
+`but commit -b <branch> ...` creates the branch when it does not exist and prints the created commit. Do not run a separate `but branch new`, status command, or verification diff unless the task needs workspace information that the result does not provide.
+
+## IDs
+
+The first token on each `but diff` / `but status` line is that line's ID. When a command needs an ID, copy it exactly from the current output; never hardcode or invent one. IDs may be a single character when unambiguous, and their lifetimes differ by entity:
+
+- Changes and sources are **positional, space-separated** IDs (`but commit -b feat -m "msg" qs:5 uo`). A hunk ID is written `<file-id>:<hunk-id>` (e.g. `qs:5`, copied from `but diff`) — the part after the colon is the hunk's ID, **not** a line range (`qs:16-40` is invalid). Do not invent flags like `--changes` / `--hunk` / `--ids`, pass a line range, or comma-separate IDs — `nk,pn` is parsed as one ID and fails.
+- `but diff` is the exception: it accepts at most **one** target. Bare `but diff` shows all uncommitted files; inspect committed files or other entities one target at a time — never `but diff <id> <id>`.
+- A committed file is `<commit-id>:<file-id>` (e.g. `uyr:n`, shown under each commit). `zz` means the uncommitted area.
+- Commit IDs are stable change IDs that survive history edits (`amend`, `squash`, `move`, `uncommit`, `reword`). Commits without a change ID (e.g. upstream-only) lead with a sha prefix instead, and `#N`-suffixed refs disambiguate duplicates — both go stale after history edits, and a stale sha can silently resolve to the wrong commit. The `(sha …)` on verbose commit lines is informational — do not pass it to commands.
+- Branch short IDs are snapshot-local selectors. Use full branch names for branch-targeting mutations; short IDs are safe only for immediate read-only inspection.
+- File/hunk IDs copied from one diff read generally remain usable across chained commits. If one stops resolving, re-read `but diff` and retry.
+
+**Chaining:** mutation output is concise by default, so you may chain mutations with `&&` off one inspection read. Do not chain branch short IDs through mutations; use full branch names. Add `--status-after` only when the next step needs workspace IDs or details that the mutation result does not provide. Chained `but commit` calls stack in the order written — the first is oldest, each later one goes on top. History edits may run in sequence when every commit ref involved is a change-ID ref; run them one at a time with `--status-after` when a ref is sha-based or `#N`-suffixed, or when the next command needs freshly issued IDs. Chaining `but uncommit <id> && but diff` is safe because bare `diff` needs no ID from the uncommit output.
+
+## Non-Negotiable Rules
+
+1. Use `but` for all write operations. Never run `git add`, `git commit`, `git push`, `git checkout`, `git merge`, `git rebase`, `git stash`, or `git cherry-pick`. If the user says a `git` write command, translate it to `but` and run that. Exception: a worktree-local Git commit when `but commit` reports that linked worktrees are unsupported. Never run `but setup` from a linked worktree.
+2. Mutation commands print their result without appending workspace status. Add `--status-after` only when the next step needs resulting workspace IDs or details; otherwise trust the mutation result and do not run a verification status/diff.
+3. Branches marked `(merged upstream)` have landed; run `but pull` to remove them, or start new work on another branch. `push` and mutations (`commit`, `amend`, `squash`, `uncommit`, `reword`, `move`) refuse landed branches and commits, `absorb` skips them with a notice, and `commit` skips them when picking a default target.
+4. In non-interactive CLI workflows, do not narrate progress between routine commands. Execute the needed `but` commands and give a concise final summary.
+5. Prefer this skill and `references/reference.md` over exploratory help calls. Use `<command> --help` when required syntax is missing or a command fails; use top-level help only when you genuinely need to discover an undocumented command.
+
+## Command Patterns
+
+- Commit: `but commit -b <branch> -m "<msg>" <id> <id>` — `-b <branch>` creates the branch if it does not exist
+- Commit everything uncommitted: `but commit -b <branch> -m "<msg>"` (omit the IDs)
+- Several commits from one diff: chain `but commit` calls with `&&` (commits stack oldest-first)
+- Commit at a specific history position: `--above <commit-or-branch>` or `--below <commit-or-branch>` instead of `-b`
+- Only one targeting flag (`-b` / `--above` / `--below`) per command. Targeting is **required** when more than one **stack** is applied; without it `but commit` fails with "Unclear where to commit. Found more than one stack". Several branches stacked together count as one stack — an untargeted commit then silently lands on the stack's top branch, so pass `-b` whenever the branch matters.
+- Always pass `-m "<msg>"` (or `--no-message`) to `but commit`, and to `but squash` whenever its sources are commits or branches unless the target is `zz` — those compose a new message, and without a flag an editor opens and blocks. Squash sources that are uncommitted or committed files reuse the target's message and need no flag; squashing into `zz` rejects message flags outright.
+- Amend: `but amend -t <commit-or-branch> <file-or-hunk-id> <file-or-hunk-id>` — a branch target resolves to its newest commit
+- Uncommit: `but uncommit <commit-id>` (whole commit), `but uncommit <branch>` (all commits and remove the branch), or `but uncommit <commit-id>:<file-id>` (one committed file); multiple committed-file sources in one call must come from one commit
+- Insert empty commit: `but commit --empty -b <branch> -m "<msg>"`
+- Squash commits: `but squash <source-commit-id> [<source-commit-id>...] -t <target-commit-id> -m "<msg>"`
+- Squash a whole branch into one commit: `but squash <branch> -m "<msg>"` (no `-t`)
+- Uncommit and remove a branch: `but uncommit <branch>`
+- Reorder commits: `but move <commit-id> --below <commit-id>` (`--above` for the other direction; **commit IDs**, not branch names)
+- Reorder a block: `but move <commit-id> <commit-id> --below <following-commit-id>` or `--above <preceding-commit-id>` (both anchors accept multiple space-separated sources)
+- Move commit to branch top: `but move <commit-id> -b <branch>`
+- Stack branches: `but move <branch-name> --above <target-branch-name>` (**use full branch names**)
+- Tear off a branch: `but move <branch> --unstack`
+- Discard: `but discard <id> [<id>...]` — accepts branches, commits, committed files, uncommitted files/hunks, or `zz` for all uncommitted changes
+- Push: `but push <top-branch>` — pushes the selected branch and its ancestors; to update a stack, select its top branch once and never loop. Bare `but push` pushes all unpushed work when run non-interactively — one push per stack (its topmost unpushed branch, ancestors included), so output has one entry per stack, not per branch. It exits non-zero if any stack failed; stacks that already pushed stay pushed, and rerunning after fixing the failure is safe (up-to-date stacks are skipped)
+- Pull (update workspace from the target): `but pull` — the output reports the result; `but pull --check` previews without updating when a preview is actually needed
+- Create PR: `but pr new <branch-name> [-m "Title..."] [-F pr_message.txt] [-t] [--draft]` — auto-pushes first; do not run `but push` before it
+
+## Task Recipes
+
+### Update workspace from main
+
+For "get latest from main", "update/sync this workspace", "rebase onto main", or "pull main":
+
+1. `but pull` — one command; no preflight needed. Its output reports the resulting state, it refuses safely when uncommitted changes conflict, and `but undo` reverts it.
+2. If commits come back conflicted, resolve them oldest-first following the printed instructions: `but resolve <commit>`, edit the files, then `but resolve finish`. Its result gives the current ID of the next conflict. Add `--status-after` to the finish you expect to clear the last conflict only when the task needs the complete resulting workspace. When it says no conflicted commits remain, stop; do not run a verification status. Finishing a lower commit rebases the ones above it, so always work bottom-up.
+
+`but pull --check` answers "would this conflict?" without updating. Do not use it as a routine
+preflight; use it when the user asks for a preview, repository policy requires one, or other agents'
+branches may move.
+
+Rebasing applied branches onto the latest target IS `but pull` — never `move`, `config target`, `unapply`, or raw `git pull`/`git rebase`. The base shown in status is the last FETCHED state: when `git log` shows `main` (local or remote) ahead of it, that is exactly the update `but pull` fetches and applies — the target setting is not stale and repointing it is never the fix. Pull carries uncommitted changes along, and its output reports the resulting state. If it refuses because uncommitted changes conflict, park them: `but commit -b <branch> -m "wip" <ids>`, pull again, then `but uncommit` the parked commit (there is no stash; do not hand-revert files).
+
+### Commit selected files or hunks
+
+1. `but diff` — shows file and hunk IDs for uncommitted changes. Do not run plain `but status` first.
+2. Use file IDs when whole files belong in the commit; use hunk IDs (`<file-id>:<hunk-id>`) when only part of a file belongs. Omit IDs you don't want committed.
+3. `but commit -b <branch> -m "<msg>" <id1> <id2>` — the branch is created if it does not exist, so no prior `but branch new` is needed.
+4. When the task requires knowing which changes remain, add `--status-after`; otherwise the created-commit result is sufficient.
+
+Edge case: if wanted and unwanted edits are in the same diff hunk, GitButler cannot split that hunk by ID. Only when the task requires keeping part of that hunk uncommitted, temporarily edit the working tree to isolate the wanted lines, commit those IDs, then restore the leftover lines so they remain uncommitted.
+
+### Amend into existing commit
+
+1. `but status -fv` (or `but show <branch-id>`) — locate file/hunk IDs and target commit IDs.
+2. `but amend -t <commit-id> <id> <id>` — one command per target commit. For several target commits, chain the amends with `&&` when every target is a change-ID ref; otherwise run them one at a time with `--status-after` to get fresh refs.
+
+### Split an existing commit
+
+Use this when an existing commit should be replaced by selected smaller commits.
+
+1. `but status -fv` when you need the source commit, branch name, or placement anchor.
+2. `but uncommit <source-commit-id> && but diff` in one shell call exposes the commit's changes and prints the resulting file and hunk IDs.
+3. Pick replacement contents from that dirty diff, not from the old committed diff.
+4. Determine the requested chronological order from the user's wording, then create the replacement commits oldest-first by chaining `but commit` calls. Do not reverse that order to match `but status`, which displays commits newest-first. `-b <branch>` puts each new commit at the TOP of that branch — if the split commit had commits above it, the replacements now sit above those preserved commits.
+5. **If commits from that branch must stay ABOVE the replacements, put the preserved block back on top instead of fighting anchors.** Do not anchor with `--above <top>`/`--below <top>` (sha/`#N` anchors go stale as each insert rewrites history). Move the block together so its internal order stays intact: append `&& but move <preserved-id> [<preserved-id>...] -b <branch>` to the commit chain. Change-ID refs from step 1 stay valid; wait for fresh output first if any preserved ref is sha-based or `#N`-suffixed.
+6. Leave unwanted changes uncommitted. Replacements created oldest-first appear newest-first in status — that is correct; do not reorder them. Add `--status-after` to the final mutation when you need to inspect the resulting order.
+
+### Reorder commits
+
+`but status` displays commits newest/top first, while task specs often list history oldest to newest — translate before moving.
+
+1. `but status` once to get commit IDs (use `-fv` only if you also need file details).
+2. `but move <source> --below <target-commit>` places source immediately below target in `but status` (older in oldest-to-newest history). `--above` places it immediately above (newer). `but move <source> -b <branch>` moves it to branch top/newest.
+3. For an adjacent block, run ONE move, anchored either way: `but move <block-id> <block-id> --below <following-commit-id>` or `but move <block-id> <block-id> --above <preceding-commit-id>`. Pick an anchor outside the block; source order does not matter and the block keeps its internal order. Add `--status-after` when you need to inspect the resulting order; do not move the anchor or block members again.
+4. For other reorders, make the smallest set of moves.
+
+### Squash commits
+
+1. `but status` for commit IDs and order.
+2. Name the sources positionally and the result/target commit with `-t`: `but squash <source> [<source>...] -t <target> -m "<new message>"`.
+3. To collapse an entire branch into one commit, pass just the branch and no `-t`: `but squash <branch> -m "<new message>"`.
+4. Multiple independent groups may run in sequence off one status read (targets keep their change-ID refs); prefer newer/top groups first. Take fresh refs only when a ref is sha-based or `#N`-suffixed.
+5. Add `--status-after` to the final squash when you need to inspect the resulting history; do not re-verify with a separate status.
+
+### Stack existing branches
+
+To make one existing branch depend on another: `but move <child-branch-name> --above <parent-branch-name>` (use full branch names; commit reordering uses commit IDs). To unstack: `but move <branch-name> --unstack`.
+
+**DO NOT** stack via `uncommit` + `branch delete` + `branch new -a` (git branch names persist after delete and it loses work), and do not use `but undo` to unstack.
+
+### Create or manage pull requests
+
+`but pr new <branch-name>` pushes the selected branch and its ancestors, then creates the PR in one step — no prior `but push`. Provide `-F pr_message.txt`, `-t`, or `-m` with real newlines (zsh/bash: `-m $'Title\n\nBody'`) so no editor opens. If forge auth is missing, run `but config forge auth`.
+
+If you do create a PR for a stacked branch, use `but pr` — not `gh pr create` (only `but pr` sets PR bases and stack metadata; `gh pr create` breaks that). To publish a whole stack: `but pr new <top-branch-name> -t`. Manage with `but pr auto-merge|set-draft|set-ready <selector>`; selectors can be a branch name, current branch/stack CLI ID, or numeric review ID. See `references/reference.md` for details.
+
+### Dependency conflict with another branch
+
+Changes that build on another branch's commits cannot land on an independent branch. `but commit` and `but amend` fail atomically ("Cannot commit: N changes could not be applied"), naming the branch and commit each rejected change depends on — nothing is committed and no `-b` branch is created.
+
+When there is a single dependency branch, the error's Hint gives the exact recovery command: `but move <your-branch> --above <dependency-branch>` to stack an existing branch on its dependency, or `but branch new <name> --anchor <dependency-branch>` when the target branch didn't exist yet. Run it, then retry the original command. When the error names dependencies without a Hint (several dependency branches, or the dependency is on the target branch itself), run `but status -fv` to see where the dependent commits live before choosing a placement.
+
+If that recovery command fails, do NOT try `uncommit`, `squash`, or `undo` as a workaround — re-run `but status -fv` to confirm both branches exist and are applied, then retry with exact branch names.
+
+### Resolve conflicted commits (after pull, move, or reorder)
+
+**NEVER use `git add`, `git commit`, `git checkout --theirs/--ours`, or any git write command during resolution.** Only `but resolve` commands plus direct file edits.
+
+Conflicts do not interrupt operations in GitButler: a rebase always completes, and commits that conflicted are marked `{conflicted}` in `but status`. Find them from the warning that history-editing commands (`move`, `discard`, …) print, from the `but pull` summary, or from `but status`. Resolve them one conflict at a time, without entering any mode. Work through one branch at a time, oldest commit first — the loop is:
+
+1. `but resolve conflicts <branch>` — shows the conflicts of that branch's oldest conflicted commit, numbered per file. Each conflict has three sections: `ours` (the new base the commit was rebased onto), `base` (common ancestor), and `theirs` (the commit's own version). Without a branch it picks the first conflicted branch and tells you which; the output also says when other conflicted commits exist.
+2. Apply one resolution per command:
+   - Merged/mixed content (the common case — combine the intent of both sides): pipe it to `but resolve apply <path>:<N>` via stdin (heredoc) or pass `--file <f>`. The content replaces the whole conflicted region; never include conflict markers.
+   - Take a side entirely: `but resolve apply <path>:<N> --ours` or `--theirs` (bare `<path>` applies the side to all conflicts in that file).
+   - Delegate one conflict to the configured AI model: `but resolve apply <path>:<N> --ai` — prefer your own merged content when you have the context.
+   - `apply` targets the same default commit as `conflicts`; when more than one branch is conflicted, pin it with `--commit <branch>`.
+3. Go back to step 1 until it reports no conflicts. Commit ids are not stable here — every apply rewrites the commit — but branch names are, so address everything by branch and never bookkeep commit ids. Partial progress is fine: a commit with unresolved conflicts left stays `{conflicted}` with exactly those conflicts.
+
+A wrong resolution is reverted with `but undo`.
+
+`but resolve <commit-id> --ai` resolves a whole commit with the configured AI model in one shot, and `but resolve --ai` without a commit resolves every conflicted commit, oldest first — acceptable as a fallback, but you usually have better context than that model does, so prefer resolving the conflicts yourself with `apply`.
+
+**Use edit mode only when you must run code against the resolution** (build/tests at that commit):
+
+1. `but resolve <commit-id>` — enters resolution mode and prints the conflict regions.
+2. **Edit the files** to remove every conflict marker — `<<<<<<<`, `|||||||` (the common-ancestor section), `=======` and `>>>>>>>` — and keep the correct content. Do NOT skip this; do NOT use `but amend` on conflicted commits.
+3. `but resolve finish` reports leftover markers, surviving uncommitted changes, every remaining conflicted commit, and the exact current `but resolve <id>` command. Add `--status-after` to the finish you expect to clear the last conflict only when the task needs the complete resulting workspace. When it says no conflicted commits remain, stop; do not run a verification status. Cancel instead with `but resolve cancel`.
+4. Repeat for remaining conflicted commits, oldest first — finishing a lower commit rebases the ones above it.
+
+### Conflicts in uncommitted files
+
+`but status` marks uncommitted files with unresolved merge conflicts `{conflicted}`; they are excluded from committable changes and outside `but resolve` mode. Edit the file to the wanted contents (or delete it), then `but resolve <path>...` to mark it resolved with that state; it then shows as an ordinary uncommitted change.
+
+## Git-to-But Map
+
+| git | but |
+|---|---|
+| `git status` | `but status` for branch/stack/commit overview; `but status -fv` for file/hunk details; `but diff` for selected dirty changes |
+| `git add` + `git commit` | `but commit -b <branch> -m ... <ids>` |
+| `git checkout -b` + commit | `but commit -b <new-branch> -m ... <ids>` |
+| `git push` | `but push <branch-name>` |
+| `git rebase -i` | `but move`, `but squash`, `but reword` |
+| `git rebase --onto` | `but move <branch> --above <new-base>` |
+| `git checkout -- <file>` / `git restore` | `but discard <id>` |
+| `git cherry-pick` | `but pick` |
+| `gh pr create` | `but pr new <branch-name> -m "Title..."` |
+
+## Notes
+
+- Read-only git inspection (`git log`, `git blame`, `git show --stat`) is allowed.
+- If `but` prints an `AGENT ACTION REQUIRED` skill warning, run the suggested command once, then reload/use the GitButler skill. If it repeats, report it instead of retrying.
+- For command syntax and flags: `references/reference.md`
+- For workspace model: `references/concepts.md`
+- For workflow examples: `references/examples.md`

--- a/.claude/skills/gitbutler/references/concepts.md
+++ b/.claude/skills/gitbutler/references/concepts.md
@@ -1,0 +1,327 @@
+# GitButler CLI Key Concepts
+
+Deep dive into GitButler's conceptual model and philosophy.
+
+## The Workspace Model
+
+### Traditional Git: Serial Branching
+
+```
+main ──┬── feature-a (checkout here, work, commit, checkout back)
+       └── feature-b (checkout here, work, commit, checkout back)
+```
+
+- Work on ONE branch at a time
+- Switch contexts with `git checkout`
+- Changes are isolated by branch
+
+### GitButler: Parallel Stacks
+
+```
+workspace (gitbutler/workspace)
+  ├─ feature-a (applied, merged into workspace)
+  ├─ feature-b (applied, merged into workspace)
+  └─ feature-c (unapplied, not in workspace)
+```
+
+- Work on MULTIPLE branches simultaneously
+- No context switching - all applied branches merged in working directory
+- Changes are ASSIGNED to branches, not isolated by checkout
+
+### Key Implications
+
+1. **No `git checkout`**: You don't switch between branches. All applied branches exist simultaneously in your workspace.
+
+2. **The `gitbutler/workspace` branch**: A merge commit containing all applied stacks. Don't interact with it directly - use `but` commands.
+
+3. **Applied vs Unapplied**: Control which branches are active:
+   - Applied branches: In your working directory
+   - Unapplied branches: Exist but not active
+   - Use `but apply`/`but unapply` to control
+
+## CLI IDs: Short Identifiers
+
+Every object gets a short, human-readable CLI ID shown in `but status`. IDs are generated per-session and are unique across all entity types (no two objects share an ID) — always read them from `but status`.
+
+```
+Commits:    1, kyn, mpq#0  (short change-ID prefix when the commit has one, sha prefix otherwise;
+                             a #N suffix disambiguates commits sharing a change ID)
+Branches:   fe, bu, ui     (unique 2–3 char substring of the branch name, e.g. "fe" from "feature-x";
+                             falls back to auto-generated ID if no unique substring exists)
+Files:      g, qs, uo      (derived from the file path, long enough to be unique)
+Hunks:      g:5, uo:d      (<file-id>:<hunk-id>; the hunk part is derived from the hunk's content)
+Committed files: kyn:n     (<commit-id>:<file-id>, shown under each commit in `but status -fv`)
+Stacks:     m0, n0          (auto-generated, 2–3 chars)
+```
+
+**Why?** Git commit SHAs are long (40 chars). CLI IDs are short, variable-length, and unique within your current workspace context. Commits, files, and hunks may use a single character when that is unambiguous.
+
+**Reading status output:** the first token on each line is that line's ID. Verbose commit lines append an informational `(sha …)` after the timestamp — it changes on every amend; do not pass it to commands.
+
+**Stability:** Branch short IDs identify branches only within the workspace snapshot that produced them; branch names remain stable across unrelated workspace mutations. File/hunk IDs copied from the current output generally remain usable across ordinary commits, so you can reference several in a row, including across chained `but commit` calls. If an ID stops resolving, re-read the diff and continue. Commit IDs are change-ID prefixes when the commit has a change ID and sha prefixes otherwise. Change-ID refs survive history edits (`amend`, `squash`, `move`, `uncommit`, `reword`); sha refs and `#N`-suffixed refs do not — a stale sha can silently resolve to the wrong commit. History edits may run in sequence off one status read when every ref involved is a change-ID ref; otherwise run them one at a time with `--status-after` to get the next ref.
+
+**Usage:** Pass these IDs as arguments to commands:
+
+```bash
+but commit -b <branch-name> -m "message" <file-or-hunk-id>   # Commit selected changes to a branch
+but amend -t <commit-id> <file-or-hunk-id> <file-or-hunk-id>  # Amend file(s) or hunk(s) into commit
+but squash <commit-id> -t <commit-id> -m "message"         # Squash commits
+```
+
+IDs are positional and space-separated. `but help cli-ids` documents every ID kind in detail.
+
+**Linked worktrees** (experimental, only with the `worktreeManipulation` feature flag on): each
+active linked worktree gets its own ID and is drawn in `but status` as a lane — a braced
+`{<branch>}` heading (the worktree name when its `HEAD` is detached) nested above the commit the
+worktree rests on — another worktree's commit included, lanes nest recursively — or standing on
+its own below the stacks when it rests outside the workspace.
+The lane lists that checkout's uncommitted files and the commits the worktree owns; in `--json`
+they appear in a top-level `worktrees` array. The worktree ID on the heading names its whole
+uncommitted area the way `zz` names the main worktree's, and `<worktree-name>:<path>` scopes a
+filename to that checkout — `zz:<path>` keeps meaning the main worktree. A filename dirty in
+several checkouts at once is ambiguous; the error suggests the scoped forms. A worktree file or
+heading ID — like `zz` for the main checkout — works as a `but commit` change and a `but amend`
+source: the change lands on the target and leaves that worktree's uncommitted area. Without a
+target flag, worktree changes commit to the tip of the worktree's own branch; an explicit target
+commit or branch does not have to be the worktree's own. One operation reads from one checkout
+at a time — a selection mixing checkouts is refused. A worktree is also a target: `but commit`,
+`but move`, and `but pick` with `-b <worktree-id-or-its-branch-name>` or `--below <worktree-id>`
+place the commit on the tip of the branch the worktree has checked out (`--above` is refused —
+that is its uncommitted area). A worktree's own commits carry ordinary commit IDs: `reword`, `move`,
+`squash`, and `pick` accept them, and the worktree's branch and checkout follow the rewrite.
+
+## Parallel vs Stacked Branches
+
+### Parallel Branches (Independent Work)
+
+Create with `but branch new <name>`:
+
+```
+main ──┬── api-endpoint (independent)
+       └── ui-update    (independent)
+```
+
+Use when:
+
+- Tasks don't depend on each other
+- Can be merged independently
+- No shared code between them
+
+Example: Adding a new API endpoint and updating button styles are independent.
+
+### Stacked Branches (Dependent Work)
+
+**To stack an existing branch** on top of another: `but move <child-branch-name> --above <parent-branch-name>`.
+
+**To create a new stacked branch** from scratch: `but branch new <name> -a <anchor>` — only use this when the child branch doesn't exist yet.
+
+```
+main ── authentication ── user-profile ── settings-page
+        (base)            (stacked)       (stacked)
+```
+
+Use when:
+
+- Feature B needs code from Feature A
+- Building incrementally on previous work
+- Creating a series of related changes
+
+Example: User profile page needs authentication to be implemented first.
+
+**Stacking two existing branches:** If both branches already exist and you need to make one depend on the other, use top-level `move`:
+```bash
+but move feature/frontend --above feature/backend
+# Now frontend is stacked on top of backend — both in the same stack
+```
+
+To tear off a branch from a stack:
+
+```bash
+but move feature/frontend --unstack
+```
+
+**Dependency tracking:** GitButler automatically tracks which changes depend on which commits. A dependent change can only be committed to the stack that contains the commits it depends on.
+
+## The Editing Model
+
+History editing is expressed as *sources* and a *target*. Sources are positional CLI IDs; the target
+is a flag. `zz` is a special ID meaning "the uncommitted area".
+
+`but squash` carries most of the model — what it does depends on the kinds you combine:
+
+| Sources          | Target (`-t`) | Operation                         | Example                       |
+| ---------------- | ------------- | --------------------------------- | ----------------------------- |
+| Commit(s)        | Commit        | Squash commits together           | `but squash mm -t nn -m "…"`  |
+| Branch           | Commit        | Squash a branch into a commit     | `but squash <branch-name> -t nn -m "…"` |
+| Commit(s)        | Branch        | Squash into the branch's newest   | `but squash mm -t <branch-name> -m "…"` |
+| Branch           | *(none)*      | Squash the branch into one commit | `but squash <branch-name> -m "…"`       |
+| Uncommitted file | Commit        | Amend the change into a commit    | `but squash a1 -t nn`         |
+| `zz`             | Commit        | Amend everything into a commit    | `but squash zz -t nn`         |
+| Commit           | `zz`          | Uncommit the commit               | `but squash mm -t zz`         |
+| Branch           | `zz`          | Uncommit and remove the branch    | `but squash <branch-name> -t zz`         |
+| Committed file   | Commit        | Move the file to another commit   | `but squash nn:a -t mm`       |
+
+**Message flags:** commits or branches compose a NEW message unless the target is `zz`, so without
+`-m` they open an editor and block — always pass one. The remaining rows reuse the target's message
+and need no flag, and `-t zz` rejects message flags outright.
+
+The two amend rows overlap with `but amend` — prefer `but amend -t nn a1`, which does only that and
+takes the same IDs. Reach for `squash` when the sources are commits, branches, or committed files,
+which `amend` does not accept.
+
+The other editing commands are narrower entry points on the same model:
+
+- `but amend -t <commit> <changes>` — amend uncommitted files/hunks into a known commit
+- `but uncommit <commits-branches-or-committed-files>` — move committed work back to uncommitted;
+  branches are removed, and committed files in one call must come from one commit
+- `but move <sources> --above|--below|--branch|--unstack` — relocate commits, committed files, or a
+  branch; this is the command with position control
+- `but discard <changes>` — drop work instead of relocating it
+
+## Dependency Tracking
+
+GitButler tracks dependencies between changes automatically.
+
+### How It Works
+
+```
+Commit C1: Added function foo()
+Commit C2: Added function bar()
+Uncommitted: Call to foo() in new code
+```
+
+The uncommitted change **depends on** C1 (because it calls `foo()`).
+
+**Implications:**
+
+1. Can't commit this change to a stack that doesn't contain C1
+2. When amending it into history, it belongs in C1 (or a commit after C1)
+3. If you try to move the change, GitButler prevents invalid operations
+
+### Why This Matters
+
+Prevents you from creating broken states:
+
+- Can't move dependent code away from its dependencies
+- Can't commit changes to the wrong stack
+- Ensures each branch remains independently functional
+
+## Empty Commits as Placeholders
+
+You can create empty commits:
+
+```bash
+but commit --empty --below nn -m "TODO: Add error handling"
+but commit --empty --above nn -m "TODO: Add error handling"
+```
+
+**Use cases:**
+
+1. **Mark future work:** Create empty commit as placeholder for changes you'll make
+2. **Organize history:** Add semantic markers in commit history
+
+Example workflow:
+
+```bash
+but commit --empty --below rr -m "TODO: Add error handling"
+# Later, amend the error handling changes into the placeholder
+but amend -t <empty-commit-id> <file-id>
+```
+
+## Operation History (Oplog)
+
+Every operation in GitButler is recorded in the oplog (operation log).
+
+### What Gets Recorded
+
+- Branch creation/deletion
+- Commits
+- Squash/amend/move/uncommit/discard operations
+- Push/pull operations
+
+### Using Oplog
+
+```bash
+but oplog                      # View history
+but undo                       # Undo last operation
+but redo                       # Redo last undone operation
+but oplog list --since <snapshot-id>
+but oplog list --snapshot
+but oplog snapshot -m "known good"
+but oplog restore <snapshot-id>  # Restore to specific point
+```
+
+Think of it as "git reflog" but for all GitButler operations, not just branch movements.
+
+**Safety net:** Made a mistake? `but undo` it. Experimented and want to go back? `but oplog restore` to earlier snapshot.
+
+## Applied vs Unapplied Branches
+
+Branches can be in two states:
+
+### Applied Branches
+
+- Active in your workspace
+- Merged into `gitbutler/workspace`
+- Changes visible in working directory
+- Can make changes and commit
+
+### Unapplied Branches
+
+- Exist but not active
+- Not in working directory
+- Can't make changes (must apply first)
+- Useful for temporarily setting aside work
+
+### Controlling State
+
+```bash
+but apply <branch-name>    # Make branch active
+but unapply <branch-name>  # Make branch inactive
+```
+
+**Use cases:**
+
+- Unapply branches causing conflicts
+- Focus on subset of work (unapply others)
+- Temporarily set aside work without deleting
+
+## Conflict Resolution Mode
+
+When `but pull` causes conflicts, affected commits are marked as conflicted.
+
+### Resolution Workflow
+
+1. **Identify:** the `but pull` summary lists each conflicted commit's ID, oldest first (`but status` also shows them)
+2. **Enter mode:** `but resolve <commit-id>` — it prints the conflict regions with line numbers. With several conflicted commits, resolve the oldest first: finishing a lower commit rebases the ones above it
+3. **Fix conflicts:** Edit files, remove conflict markers (`but resolve status` re-lists what remains when several files are conflicted)
+4. **Finalize:** `but resolve finish` or `but resolve cancel` — finish reports leftover markers and the surviving uncommitted changes, so no follow-up check is needed
+
+### During Resolution
+
+- You're in a special mode focused on that commit
+- Other GitButler operations are limited
+- `but status` shows you're in resolution mode
+- Must finish or cancel before continuing normal work
+
+## Read-Only Git Commands
+
+Git commands that don't modify state are safe to use:
+
+**Safe (read-only):**
+
+- `git log` - View history
+- `git diff` - See changes (but prefer `but diff` — it supports CLI IDs)
+- `git show` - View commits
+- `git blame` - See line history
+- `git reflog` - View reference log
+
+**Don't use in a GitButler workspace:**
+
+- `git status` - Misleading: shows merged workspace state, not individual stacks; missing CLI IDs that agents need
+- `git commit` - Commits to the workspace merge commit, not your branch
+- `git checkout` - Breaks workspace model
+- `git rebase` - Conflicts with GitButler's management
+- `git merge` - Use `but land` instead
+
+**Rule of thumb:** If it reads, it's fine. If it writes, use `but` instead.

--- a/.claude/skills/gitbutler/references/examples.md
+++ b/.claude/skills/gitbutler/references/examples.md
@@ -1,0 +1,475 @@
+# GitButler CLI Workflow Examples
+
+Real-world examples of common workflows.
+
+**Note on CLI IDs:** Examples below use full branch names for branch-targeting mutations. Illustrative IDs like `nn` and `a1` keep other commands readable; in practice, **always read actual IDs from `but status -fv`** because they are generated for the current workspace snapshot. Commit IDs are short change-ID prefixes that stay stable across history edits (e.g., `kyn`; commits without a change ID fall back to a sha prefix), and file/hunk/stack IDs are auto-generated (e.g., `r`, `r:c`, `h0`). All IDs are unique across entity types within one snapshot.
+
+## Example 1: Starting Independent Parallel Work
+
+**Scenario:** Need to work on two independent features: a new API endpoint and UI styling updates.
+
+```bash
+# 1. Check current state
+but status -fv
+
+# 2. Create two independent (parallel) branches
+but branch new api-endpoint
+but branch new ui-styling
+
+# 3. Make changes to multiple files
+# (edit api/users.js and components/Button.svelte)
+
+# 4. Check what's uncommitted
+but status -fv
+
+# 5. Commit specific files by passing their CLI IDs (recommended for agents)
+# Use full branch names plus file IDs from but status -fv output
+# Multiple IDs are space-separated positional arguments.
+but commit -b api-endpoint -m "Add user details endpoint" <api-file-id>
+but commit -b ui-styling -m "Update button hover styles" <ui-file-id>
+
+# Follow-up fix that belongs in a commit you just made? Amend it in.
+# Add --status-after only when the next step needs resulting workspace IDs or details.
+# but amend -t <api-commit-id> <api-fix-file-id> <api-fix-hunk-id>
+
+# 6. Create pull requests (auto-pushes the branches; -m sets the PR title so no editor opens)
+but pr new api-endpoint -m "Add user details endpoint"
+but pr new ui-styling -m "Update button hover styles"
+```
+
+**Why parallel branches?** The API endpoint and UI styling are independent - neither depends on the other. They can be reviewed and merged separately.
+
+## Example 2: Building Stacked Features
+
+**Scenario:** Need to add authentication, then build a user profile page that requires auth.
+
+```bash
+# 1. Check current state and update
+but pull
+but status -fv
+
+# 2. Create base branch for authentication
+but branch new add-authentication
+
+# 3. Implement auth and commit
+# (edit auth/login.js, auth/middleware.js)
+but status -fv
+but commit -b add-authentication -m "Add JWT authentication" <file-ids>
+
+# 4. Create stacked branch anchored on authentication
+but branch new user-profile -a add-authentication
+
+# 5. Implement profile page (depends on auth)
+# (edit pages/profile.js)
+but status -fv
+but commit -b user-profile -m "Add user profile page" <file-ids>
+
+# 6. Create stacked pull requests from the top branch once (auto-pushes its ancestors)
+but pr new user-profile -t
+```
+
+**Result:** Two PRs where user-profile targets add-authentication, with GitButler stack information in the PR descriptions.
+
+## Example 3: Amending Fixes Into Existing Commits
+
+**Scenario:** Made a small typo fix that should be part of an existing commit, not a new commit.
+
+```bash
+# 1. Check current commits and uncommitted changes
+but status -fv
+
+# Output shows:
+# Branch: feature-x (bu)
+# Commits:
+#   nn: Implement feature logic
+#   mm: Add feature tests
+# Uncommitted:
+#   a1: fix-typo.js
+
+# 2. Decide which commit the fix belongs to
+# (the typo is in code introduced by nn, so it belongs in nn)
+
+# 3. Amend the file into that commit
+but amend -t nn a1    # Amend just this file + get updated status
+```
+
+**Why amend?** Keeps history clean. Small fixes belong in the commits they fix, not as separate "fix typo" commits. You know what you changed and why — pick the target commit yourself.
+
+## Example 4: Reorganizing Commit History
+
+### Scenario A: Squashing Commits
+
+**Situation:** Made 5 small WIP commits, want to combine into one logical commit.
+
+```bash
+# Before (newest first):
+# rr: More tweaks
+# pp: Fix another thing
+# nn: Fix tests
+# mm: Adjust logic
+# kk: Initial implementation
+
+# Squash all commits in the branch into one
+but squash feature -m "Implement feature"
+
+# Or squash specific commits into a target commit
+but squash rr pp nn mm -t kk -m "Implement feature"
+```
+
+### Scenario B: Moving Files Between Commits
+
+**Situation:** A file was committed in the wrong commit, need to move it.
+
+```bash
+# 1. See which files are in which commits
+but status -fv
+
+# Output shows:
+# nn: Add API layer
+#   nn:a1  api.js
+#   nn:a2  utils.js
+# mm: Add config
+#   mm:c1  config.js
+
+# 2. Move utils.js from nn to mm
+but squash nn:a2 -t mm -u    # Committed file nn:a2 (utils.js) → commit mm, keep mm's message
+```
+
+### Scenario C: Moving Commit to Different Branch
+
+**Situation:** Committed to wrong branch, need to move commit.
+
+```bash
+# 1. Check current state
+but status -fv
+
+# Output:
+# Branch: feature-a (bu)
+#   nn: This should be in feature-b!
+#   mm: Correct commit
+
+# 2. Create or identify target branch
+but branch new feature-b    # Creates branch bv
+
+# 3. Move the commit
+but move nn -b feature-b    # Move nn to top of feature-b
+```
+
+## Example 5: Stacking Existing Branches
+
+**Scenario:** Two independent branches exist, but one now depends on the other. Stack them.
+
+```bash
+# 1. Check current state — two independent branches in separate stacks
+but status -fv
+
+# Output:
+# Stack 1: feature/backend (bu) — 2 commits
+# Stack 2: feature/frontend (bv) — 1 commit
+
+# 2. Frontend now depends on backend API — stack frontend on backend
+#    IMPORTANT: Use full branch names; short IDs belong to the previous snapshot
+but move feature/frontend --above feature/backend
+
+# Result: Both branches are now in the same stack:
+# Stack 1: feature/backend → feature/frontend (stacked)
+
+# 3. Continue working — commits go to the right branch
+but status -fv
+but commit -b feature/backend -m "Add caching layer" <id>
+but commit -b feature/frontend -m "Add dialog component" <id>
+```
+
+**Key point:** branch stack moves use full branch names like `feature/frontend`. Commit reordering still uses commit IDs.
+
+## Example 6: Conflict Resolution
+
+**Scenario:** After `but pull`, conflicts appear in a commit.
+
+```bash
+# 1. Pull updates
+but pull
+
+# Output:
+# Summary
+# ────────
+#   feature-x - conflicted
+#       nn Add validation
+
+# 2. Enter resolution mode using the commit ID from the pull output
+but resolve nn
+
+# Output:
+# Checking out conflicted commit nn
+# Conflicted files remaining:
+#   ✗ api/users.js
+#      12│<<<<<<< New base: ...
+#      ...conflict regions with line numbers...
+
+# 3. Edit each conflicted file to resolve
+# IMPORTANT: You MUST edit the files — do NOT just run `but resolve finish`
+# NEVER use `git add`, `git checkout --theirs/--ours`, or any git write command — just edit the files directly with the Edit tool, then `but resolve finish`
+# (edit to remove every marker — <<<<<<< ||||||| ======= >>>>>>> — and keep correct content;
+#  with several conflicted files, `but resolve status` re-lists what remains)
+
+# 4. Finalize
+but resolve finish
+
+# Output:
+# ✓ Conflict resolution finalized successfully!
+# No conflict markers remain in the resolved files.
+# Workspace restored; uncommitted changes intact: ...
+# No follow-up status or marker scan needed — finish already reports both.
+```
+
+## Example 7: Complete Feature Development Workflow
+
+**Scenario:** Building a complete feature from start to finish.
+
+```bash
+# 1. Update to latest
+but pull
+
+# 2. Create branch for feature
+but branch new user-dashboard
+
+# 3. Make initial changes
+# (create dashboard.js, add routes)
+
+# 4. Check status and gather file IDs
+but status -fv
+
+# 5. First commit
+but commit -b user-dashboard -m "Add dashboard route and basic layout" <file-ids>
+
+# 6. Continue iterating
+# (add widgets, styling)
+but commit -b user-dashboard -m "Add dashboard widgets" <file-ids>
+but commit -b user-dashboard -m "Style dashboard components" <file-ids>
+
+# 7. Make small fix
+# (fix typo in widget)
+but amend -t <commit-id> a1    # Amend fix into the commit it belongs to
+
+# 8. Clean up if needed
+but squash user-dashboard -m "Add user dashboard"    # Combine all commits (optional)
+
+# 9. Create pull request (auto-pushes the branch)
+but pr new user-dashboard -m "Add user dashboard"
+
+# Output:
+# Created PR #123: https://github.com/org/repo/pull/123
+
+# 10. After PR is merged, update
+but pull
+```
+
+## Example 8: Working with Applied/Unapplied Branches
+
+**Scenario:** Have 3 branches, but two are causing conflicts. Temporarily unapply them.
+
+```bash
+# 1. Check active branches
+but status -fv
+
+# Output:
+# Applied branches:
+#   bu: feature-a
+#   bv: feature-b
+#   bw: feature-c
+
+# 2. Conflicts between feature-b and feature-c
+# Unapply them temporarily
+but unapply feature-b
+but unapply feature-c
+
+# 3. Focus on feature-a
+# (make changes, commit)
+but commit -b feature-a -m "Complete feature-a" <file-ids>
+
+# 4. Create PR for feature-a (auto-pushes)
+but pr new feature-a -m "Complete feature-a"
+
+# 5. Reapply other branches
+but apply feature-b
+but apply feature-c
+
+# 6. Deal with their conflicts now
+but resolve ...
+```
+
+## Example 9: Fixing History Before Pushing
+
+**Scenario:** Made several commits, realized you need to reword messages and reorder.
+
+```bash
+# 1. Current state
+but status -fv
+
+# Output (newest first):
+# Branch: feature-x (bu)
+#   rr: final commit
+#   pp: WIP
+#   nn: Fix stuff
+#   mm: Another fix
+#   kk: Initial
+
+# 2. Reword commit messages — commit refs are change-ID based and stay
+#    valid across rewords and other history edits
+but reword pp -m "Add validation logic"
+but reword nn -m "Fix edge case in parser"
+but reword mm -m "Update error messages"
+
+# 3. Move rr to be earlier
+but move rr --below nn    # Place rr directly below nn
+
+# 4. Squash similar commits
+but squash mm -t nn -u    # Combine error handling commits; -u keeps nn's message, drops mm's
+
+# Output (newest first):
+# Branch: feature-x (bu)
+#   pp: Add validation logic
+#   nn: Fix edge case in parser
+#   rr: final commit
+#   kk: Initial
+
+# 5. Push clean history
+but push feature-x
+```
+
+## Example 10: Daily Development Workflow
+
+**Typical day working with GitButler:**
+
+```bash
+# Morning: Start day
+but pull    # Get latest from team
+
+# Start new task
+but branch new fix-auth-bug  # Create branch for today's work
+
+# Work and commit iteratively
+# (make changes)
+but status -fv              # Check changes
+but commit -b fix-auth-bug -m "Identify auth bug source" <file-ids>
+# (make more changes)
+but commit -b fix-auth-bug -m "Fix token expiration handling" <file-ids>
+# (small fix to existing code)
+but amend -t <commit-id> a1  # Amend fix into the commit it belongs to
+
+# Mid-day: Start urgent fix on different branch
+but branch new hotfix-login  # Parallel branch for urgent work
+# (make fix)
+but commit -b hotfix-login -m "Fix login redirect loop" <file-ids>
+but pr new hotfix-login -m "Fix login redirect loop"    # Push and create PR immediately
+
+# Back to original work
+# (continue working on fix-auth-bug)
+but commit -b fix-auth-bug -m "Add tests for token handling" <file-ids>
+
+# End of day: Clean up and create PR
+but squash fix-auth-bug -m "Fix auth bug"    # Combine into clean history
+but pr new fix-auth-bug -m "Fix auth bug"    # Push and create PR
+
+# After PR review: Make requested changes
+# (make changes based on feedback)
+but amend -t <commit-id> <file-id>  # Amend each fix into the commit it belongs to
+but push fix-auth-bug   # Push updated history
+```
+
+## Example 11: Recovering from Mistakes
+
+**Scenario:** Made changes you didn't mean to, need to undo.
+
+### Undo Last Operation
+
+```bash
+# Made a mistake
+but squash feature -m "..."    # Oops! Didn't mean to squash
+
+# Undo it
+but undo         # Reverts the squash
+```
+
+### Restore to Earlier Point
+
+```bash
+# View operation history
+but oplog
+
+# Output (snapshot refs are git SHAs, not CLI IDs):
+# 9c1f2ab 2026-01-02 [SQUASH] Squashed commits
+# f8a3733 2026-01-02 [COMMIT] Created commit
+# 4b70e19 2026-01-02 [AMEND] Amended commit
+# 1d5c806 2026-01-02 [BRANCH] Created branch
+
+# Restore to before the squash, using the SHA from the output
+but oplog restore f8a3733
+```
+
+### Discard Uncommitted Changes
+
+```bash
+# Changed a file but want to discard
+but status -fv
+
+# Output:
+# Uncommitted:
+#   a1: bad-changes.js
+
+# Discard it
+but discard a1
+```
+
+## Tips and Tricks
+
+### Quick Status Check
+
+```bash
+but status -fv    # File-centric view for quick overview
+```
+
+### Preview Before Doing
+
+```bash
+but push my-feature --dry-run   # See what would be pushed
+```
+
+### Multiple Commits From One Diff
+
+File/hunk IDs copied from the original output generally remain usable across
+commits. Chain `but commit` calls to split a dirty diff into several commits in
+one go:
+
+```bash
+but diff   # read the file/hunk IDs once
+
+but commit -b my-branch -m "Add parser" qs:5 qs:2 \
+  && but commit -b my-branch -m "Add tests" uo:d
+```
+
+The commits stack in the order you write them, so `Add parser` ends up below (older
+than) `Add tests`. Chain these commit commands when each references uncommitted IDs
+and a full branch name. If an ID stops resolving, re-read the diff and continue.
+Mutation output is concise by default. Add `--status-after` only when the next
+step needs workspace IDs or details that the mutation result does not provide.
+History edits — `amend`, `squash`, `move`, `uncommit`, `reword` — may also run in
+sequence off one status read when every commit ref involved is a change-ID ref;
+those stay stable across the edits. Run them one at a time when a ref is sha-based
+or `#N`-suffixed, or when the next command needs freshly issued IDs, and add
+`--status-after` to get them.
+
+
+### Auto-completion
+
+```bash
+eval "$(but completions zsh)"     # Add to ~/.zshrc
+eval "$(but completions bash)"    # Add to ~/.bashrc
+```
+
+### Viewing History
+
+```bash
+but show bu       # Show all commits in branch
+git log bu               # Traditional git log (read-only, still works)
+```

--- a/.claude/skills/gitbutler/references/reference.md
+++ b/.claude/skills/gitbutler/references/reference.md
@@ -1,0 +1,636 @@
+# GitButler CLI Command Reference
+
+Agent-focused reference for useful `but` commands.
+
+## Contents
+
+- [Inspection](#inspection-understanding-state) - `status`, `show`, `diff`, `open`
+- [Branching](#branching) - `branch new`, `apply`, `unapply`, `branch delete`, `pick`
+- [Committing](#committing) - `commit`
+- [Editing History](#editing-history) - `squash`, `amend`, `move`, `uncommit`, `reword`, `discard`
+- [Conflict Resolution](#conflict-resolution) - `resolve`
+- [Remote Operations](#remote-operations) - `push`, `pull`, `pr`, `land`
+- [Workspace Maintenance](#workspace-maintenance) - `clean`, `worktree`
+- [History & Undo](#history--undo) - `undo`, `oplog`
+- [Setup & Configuration](#setup--configuration) - `setup`, `teardown`, `config`, `update`, `skill`
+- [Selected Options](#selected-options)
+
+## Inspection (Understanding State)
+
+### `but status`
+
+Overview of branch, stack, commit, and workspace state. Use this when you need existing branch/stack/commit/conflict context. For selected dirty-file or hunk commits, start with `but diff` instead.
+
+```bash
+but status              # Compact overview with branch, stack, commit IDs, and commit subjects
+but status -fv          # File-centric view with full commit details and file IDs
+but status --verbose    # Detailed information
+but status --upstream   # Show upstream relationship
+```
+
+Shows:
+
+- Applied/unapplied branches in workspace
+- Uncommitted and assigned changes
+- Commits on each stack
+- CLI IDs to use in other commands
+
+The first token on each line is that line's ID. A `<branch-selector>` is a full branch name or short ID from the current workspace snapshot. Short IDs may be reassigned as that context changes; branch names remain stable across unrelated workspace mutations. Agents should use full branch names for branch-targeting mutations. Commit lines lead with the commit's change ID (stable across history edits); commits without a change ID lead with a sha prefix, which goes stale after history edits. Verbose output appends an informational `(sha …)` after the timestamp — do not pass the sha to commands.
+
+### `but show <id>`
+
+Details about a commit or branch.
+
+```bash
+but show <id>           # Show details
+but show <id> --verbose # Show with full messages and file details
+```
+
+### `but diff [target]`
+
+Display diff for file, branch, stack, or commit.
+
+```bash
+but diff                # Diff for entire workspace; best first command for selective dirty commits
+but diff <file-id>      # Diff for specific file
+but diff <branch-id>    # Diff for all changes in branch
+but diff <commit-id>    # Diff for specific commit
+```
+
+`but diff` accepts at most one target. Bare `but diff` shows every uncommitted file;
+inspect committed files or other entities one target at a time. Unlike `commit`,
+`amend`, and `discard`, it does not accept several positional IDs.
+
+**Hunk IDs:** For uncommitted changes, `but diff` shows each hunk with an ID (e.g., `qs:5`, `uo:d`). Pass these IDs to `but commit` for fine-grained, hunk-level commits.
+
+For the full CLI ID model, `but help cli-ids` documents every ID kind and its stability.
+
+### `but open [target]`
+
+Open the GitButler app at a branch or commit, or print the link with `--print`.
+
+```bash
+but open                    # The workspace
+but open <branch-id>        # With that branch selected
+but open <commit-id>        # With that commit selected
+but open --print <id>       # Print the link instead of opening it
+```
+
+Commits are addressed by change ID where they have one, so the link keeps
+working after the commit is amended or rebased.
+
+## Branching
+
+### `but branch`
+
+List all branches (default when no subcommand).
+
+```bash
+but branch              # List branches
+but branch list [filter]  # Filter branches by name (case-insensitive substring)
+but branch list --no-ahead  # Skip commits-ahead calculation (faster)
+but branch list --no-check  # Skip clean-merge check (faster)
+but branch list -r      # Show only remote branches
+but branch list -l      # Show only local branches
+but branch list -a      # Show all branches (not just active + 20 most recent)
+but branch list --empty  # Include empty branches
+but branch list --review  # Fetch and display review information
+```
+
+To rename an applied branch, use `but reword <branch> -m "new-name"` (unapplied branches cannot be renamed).
+
+### `but branch new [name]`
+
+Create a new branch.
+
+```bash
+but branch new                      # Generated branch name
+but branch new feature              # Independent branch (parallel work)
+but branch new feature -a <anchor>  # Stacked branch (dependent work)
+```
+
+Use parallel branches for independent tasks. Use stacked branches when work depends on another branch.
+
+In single-branch mode (no managed workspace), `but branch new` stacks the new branch above the checked-out branch (or the `-a` anchor). When the new branch lands above the checked-out branch — always the case without an anchor — it is checked out and `HEAD` moves to it.
+
+For "commit these selected changes on a new branch", prefer `but commit -b <branch> -m "message" <ids>` instead of a separate `but branch new` or preflight `but status -fv` — `-b` creates the branch when it does not exist.
+
+### `but apply <branch-name>`
+
+Activate a branch in the workspace.
+
+```bash
+but apply feature-branch  # Activate branch in workspace
+```
+
+Default human output reports whether the branch was applied, was already active, or conflicted. Conflicts are reported as non-zero CLI errors.
+
+### `but unapply <selector>`
+
+Deactivate a branch from the workspace.
+
+```bash
+but unapply <selector> # Deactivate branch from workspace
+```
+
+The command also accepts a current CLI ID pointing to a stack or branch, but agents should use the full branch name. The entire stack containing that branch will be unapplied.
+
+### `but branch delete <branch-selector>`
+
+Delete a branch.
+
+```bash
+but branch delete <branch-selector>
+but branch -d <branch-selector>      # Short form
+```
+
+### `but branch show <id>`
+
+Show commits ahead of base for a branch.
+
+```bash
+but branch show <id>
+but branch show <id> -f       # Show files modified in each commit with line counts
+but branch show <id> --ai     # Generate AI summary of branch changes
+but branch show <id> --check  # Check if branch merges cleanly into upstream
+but branch show <id> -r       # Fetch and display review information
+```
+
+### `but pick [SOURCES]...`
+
+Cherry-pick commits from unapplied branches into applied branches.
+
+```bash
+but pick <commit-sha> --branch <branch>       # Pick specific commit into branch
+but pick <cli-id> --branch <branch>           # Pick using CLI ID (e.g., "nn")
+```
+
+Name both the source commit and the target branch. Omitting the target prompts
+for one when several branches exist. The source can be a commit SHA (full or
+short) or a CLI ID from `but status`.
+
+## Committing
+
+### `but commit [CHANGES]...`
+
+Create a commit. Changes are positional CLI IDs; where the commit goes is a flag.
+
+```bash
+but commit -b <branch> -m "message"          # Commit ALL uncommitted changes to branch
+but commit -b <branch> -m "message" <id> <id>  # Commit specific files or hunks by CLI ID
+but commit -b <branch> -m "msg" -m "body"    # Repeat -m; parts joined by a blank line
+but commit --above <target> -m "message" <id>  # Place the commit above a commit or branch
+but commit --below <target> -m "message" <id>  # Place the commit below a commit or branch
+but commit -b <branch> --no-message <id>     # Commit without a message
+but commit --empty -b <branch> -m "message"  # Insert an empty commit
+```
+
+**Where the commit goes:** `-b`/`--branch`, `-A`/`--above`, and `-B`/`--below` are mutually exclusive.
+
+- `-b <branch>` places the commit at the tip of `<branch>`, creating it as an unstacked branch if it does not exist. `-b` with no value creates a branch with a generated name. Targeting a branch that exists but is not applied is an error — except a branch checked out in a linked worktree (experimental worktree flag), which is targeted at its tip, as is a worktree named directly.
+- `--above <commit>` / `--below <commit>` insert relative to a commit on that commit's branch. Against a branch, they create a new branch above/below it. Against a linked worktree (experimental worktree flag), `--below` targets the tip of its checked-out branch and `--above` is refused.
+- With no branches applied, a new branch is created. With one applied stack, the commit goes to its top branch's tip. With more than one stack, a targeting flag is **required** — otherwise the command fails with "Unclear where to commit. Found more than one stack". The gate is stacks, not branches: several branches stacked together take an untargeted commit on the stack's top branch.
+
+**Important:** `but commit -b <branch> -m "msg"` with no IDs commits ALL uncommitted changes. Pass IDs to commit only specific files or hunks.
+
+`but commit` is not supported from linked worktrees. Use Git directly for the worktree-local commit, and do not run `but setup` there.
+
+**Committing specific files or hunks:** Start with `but diff` for selective dirty commits, then pass CLI IDs as positional arguments:
+- **File IDs** from `but diff` or `but status -fv`: commits entire files
+- **Hunk IDs** (`<file-id>:<hunk-id>`) from `but diff`: commits individual hunks
+- IDs are space-separated (`<id> <id>`). Commas are not separators — `a1,b2` is parsed as a single ID and fails to resolve.
+
+**Placing commits:** Use `--above <target>` or `--below <target>` when the new commit should be inserted at a specific position in existing history. Change-ID refs of existing commits remain valid after an insertion; sha and `#N`-suffixed refs may go stale — add `--status-after` when subsequent history edits need fresh refs.
+
+**Several commits from one diff:** Chain `but commit` calls with `&&` to split a broad uncommitted change into several semantic commits: `but commit -b <branch> -m "msg1" a1 b2 && but commit -b <branch> -m "msg2" c3 d4`. Mutation output is concise by default. Add `--status-after` only when the next step needs workspace IDs or details that the mutation result does not provide. The commits stack in the order you write them — the first `but commit` is the oldest of the new commits and each later one goes on top (newest). File/hunk IDs copied from the original output generally remain usable across commits; if an ID stops resolving, re-read the diff and continue. History edits (`amend`, `squash`, `move`, `uncommit`, `reword`) may run in sequence off one status read when every commit ref involved is a change-ID ref; run them one at a time with `--status-after` when a ref is sha-based or `#N`-suffixed, or when the next command needs freshly issued IDs. Bare `but diff` needs no ID from the preceding command, so `but uncommit <id> && but diff` is safe. If commits from that branch must stay *above* the new ones, see "Split an existing commit" in SKILL.md: commit the replacements, then move the preserved block together with `but move <preserved-id> [<preserved-id>...] -b <branch>` so its internal order stays intact.
+
+Example: `but commit -b my-branch -m "Fix bug" ab cd` commits files/hunks `ab` and `cd`.
+
+Example new branch: `but commit -b feature/contact-form -m "Validate contact form input" ab cd` creates `feature/contact-form` and commits only those selected file or hunk IDs.
+
+To commit specific hunks from a file with multiple changes, use `but diff` to see hunk IDs, then specify them individually.
+
+Edge case: if wanted and unwanted edits are in the same hunk, GitButler cannot split that hunk by ID. Only when the task requires keeping part of that hunk uncommitted, temporarily edit the working tree to isolate the wanted lines, commit those IDs, then restore the leftover lines so they remain uncommitted.
+
+## Editing History
+
+### `but squash <SOURCES>... [-t <target>]`
+
+Move changes into a target. Sources are positional; the target is `-t`/`--target`.
+This one command covers squashing, amending, and uncommitting.
+
+```bash
+but squash <commit> -t <commit> -m "msg"           # Squash one commit into another
+but squash <commit> <commit> -t <commit> -m "msg"  # Squash several commits into a target
+but squash <branch> -m "msg"                       # Squash all commits on a branch into one
+but squash <branch> -t <commit> -m "msg"           # Squash a branch into a commit, removing the branch
+but squash <commit> -t <branch> -m "msg"           # Target a branch: squashes into its newest commit
+but squash <file-or-hunk-id> -t <commit>           # Amend an uncommitted change (`but amend` does this)
+but squash zz -t <commit>                          # Amend all uncommitted changes into a commit
+but squash <commit> -t zz                          # Uncommit a commit
+but squash <branch> -t zz                          # Uncommit all commits and remove the branch
+but squash <commit-id>:<file-id> -t <commit>       # Move a committed file into another commit
+```
+
+All sources must be the same kind (all commits, all branches, all uncommitted changes, `zz`, or all
+committed files) and committed-file sources must come from one commit. If `-t` is omitted, `<SOURCES>`
+must be exactly one branch, which squashes that branch's commits together.
+
+Message flags (mutually exclusive). Commit and branch sources compose a new message unless the
+target is `zz`, so without a flag they open an editor and block — always pass one. Uncommitted and
+committed-file sources reuse the target's message and need no flag:
+
+```bash
+-m "msg"                # New message; repeat -m to append paragraphs
+--no-message            # No message
+-u, --use-target-message  # Keep the target's message, drop the sources'
+--use-source-message      # Keep the sources' message, drop the target's
+```
+
+None of the message flags may be used when the target is `zz`.
+
+For multiple independent squash groups, prefer newer/top groups first; change-ID refs from
+one status read stay valid across squashes (the target keeps its ref), so the
+groups may run in sequence — use `--status-after` to get fresh refs only
+when a ref is sha-based or `#N`-suffixed.
+
+### `but amend -t <commit-or-branch> <SOURCES>...`
+
+Amend uncommitted files/hunks into a specific commit. Use when you know exactly which commit the change belongs to — prefer it over the equivalent `squash` form. Sources must be uncommitted; `amend` rejects commits and committed files, so use `squash` or `move` for those. A branch target resolves to that branch's newest commit, so name the commit explicitly when the change belongs further down.
+
+```bash
+but amend -t <commit-id> <file-id> <hunk-id>
+but amend -t <branch> <file-id>       # Amends into the branch's newest commit (its tip)
+```
+
+Decide the target commit yourself: check `but status -fv`, find the commit the change logically belongs to, then amend into it.
+
+### `but move <SOURCES>... <--above|--below|--branch|--unstack>`
+
+Move commits, committed files, or a branch to a different location. Sources are positional and
+space-separated; a target flag is required.
+
+```bash
+but move <commit> --below <target-commit>          # Place below target (older) — matches status order
+but move <commit> --above <target-commit>          # Place above target (newer)
+but move <commit> <commit> --below <target-commit> # Move an adjacent block in one command
+but move <commit> <commit> --above <target-commit> # Same block move, anchored from the other side
+but move <commit> -b <branch>                      # Move commit to the tip of a branch (created if missing)
+but move <commit> --unstack                        # Move commit onto a new unstacked branch
+but move <branch> --above <target-branch>          # Stack branch on top of target branch
+but move <branch> --unstack                        # Tear off (unstack) a branch
+but move <commit-id>:<file-id> --above <commit>    # Move a committed file into a new commit above another
+```
+
+Sources may not mix kinds, all committed files must come from the same commit, and only one branch
+may be moved at a time. Source order does not matter. For a branch source only `--above` and
+`--unstack` apply; `--below` and `-b <name>` require commit or committed-file sources. `--branch`
+with no value is equivalent to `--unstack`. With the experimental worktree flag on, `-b` also
+accepts a linked worktree or the branch checked out in it, moving commit or committed-file
+sources onto that branch's tip (nothing is created); a branch source is refused there.
+
+### `but uncommit <SOURCES>...`
+
+Move commits, branches, or committed files back to the uncommitted area.
+
+```bash
+but uncommit <commit-id>                 # Uncommit an entire commit
+but uncommit <branch>                    # Uncommit all commits and remove the branch
+but uncommit <commit-id>:<file-id>       # Uncommit one file from its commit
+```
+
+Multiple whole commits or multiple branches may be passed together, but source kinds cannot be
+mixed. Uncommitting a branch also removes an empty branch. Multiple committed-file sources must all
+come from the same commit; uncommit files from different commits in separate commands.
+
+When you need file and hunk IDs to recommit selectively, use
+`but uncommit <id> && but diff` in one shell call.
+
+### `but reword <id>`
+
+Reword commit message or rename branch.
+
+```bash
+but reword <id> -m "new"          # Always pass -m; without it an editor opens and blocks
+but reword <branch> -m "new-name" # Rename a branch (applied branches only)
+but reword <id> --fix-formatting  # Format to 72-char wrapping
+```
+
+### `but discard <CHANGES>...`
+
+Permanently drop branches, commits, or changes. Undo with `but undo`.
+
+```bash
+but discard <file-id>              # Discard an uncommitted file's changes
+but discard <hunk-id>              # Discard a single hunk
+but discard zz                     # Discard all uncommitted changes
+but discard <commit-id>            # Drop a commit
+but discard <commit-id>:<file-id>  # Drop one file's changes from its commit
+but discard <branch>               # Drop a branch and its commits
+```
+
+All provided IDs must be the same kind, and committed files must come from the same commit.
+
+## Conflict Resolution
+
+When commits have conflicts (history-editing commands warn about newly conflicted commits in their output; the `but pull` summary lists them; `but status` marks them as conflicted):
+
+### `but resolve <commit>`
+
+Enter resolution mode for a conflicted commit.
+
+```bash
+but resolve <commit-id>
+```
+
+### `but resolve <path>...`
+
+Mark uncommitted files that `but status` lists as `{conflicted}` resolved with their current worktree content (or as deleted). They then show as ordinary uncommitted changes.
+
+```bash
+but resolve src/lib.rs
+```
+
+### `but resolve status`
+
+Show remaining conflicted files.
+
+```bash
+but resolve status
+```
+
+### `but resolve finish`
+
+Finalize conflict resolution.
+
+```bash
+but resolve finish
+but resolve finish --status-after  # When clearing the last conflict and its workspace is needed
+```
+
+The concise result reports leftover markers, surviving uncommitted changes, every remaining
+conflicted commit, and the exact current `but resolve <id>` command. Add `--status-after` to the
+finish you expect to clear the last conflict only when the task needs the complete resulting
+workspace. When it says no conflicted commits remain, stop; do not run a verification status.
+
+### `but resolve cancel`
+
+Cancel conflict resolution and return to workspace mode.
+
+```bash
+but resolve cancel
+but resolve cancel --force
+```
+
+**Workflow:**
+
+1. `but resolve <commit-id>` — enter resolution mode using the commit ID from the `but pull` summary (or `but status`); the conflict regions are printed with line numbers
+2. Edit the conflicted files — remove every marker (`<<<<<<<`, `|||||||`, `=======`, `>>>>>>>`; conflicts are diff3-style, so the `|||||||` common-ancestor section is present too) and keep the correct content (`but resolve status` re-lists what remains when several files are conflicted)
+3. Finalize with `but resolve finish`; add `--status-after` to the finish you expect to clear the last conflict only when the task needs the complete resulting workspace. When it says no conflicted commits remain, stop; do not run a verification status
+4. If multiple commits are conflicted, repeat steps 1-3 for each one, oldest commit first — finishing a lower commit rebases the ones above it
+
+**Important:** Never use `git add`, `git commit`, or other git write commands during conflict resolution. Only use `but resolve` commands and edit files directly.
+
+## Remote Operations
+
+### `but push <branch>`
+
+Push a selected branch and its ancestors to the remote. To update a whole stack, select its top branch once; never loop over the branches. Always specify which branch to push: without one, `but push` prompts for a selection in interactive terminals (one entry per stack, folding in stack ancestors) and otherwise pushes all unpushed work — one push per stack via its topmost unpushed branch, so output has one entry per stack, not per branch. A batch push exits non-zero if any stack failed; stacks that already pushed stay pushed, and rerunning after fixing the failure is safe since up-to-date stacks are skipped. Accepts a full branch name or a branch CLI ID — prefer the name; it stays valid across mutations.
+
+```bash
+but push <branch-name>             # Push the selected branch and its ancestors
+but push <branch-name> --dry-run   # Preview what would be pushed
+but push <branch-name> -s          # Skip force push protection checks
+but push <branch-name> --no-hooks  # Bypass pre-push hooks (--no-verify also works)
+```
+
+Force push is enabled by default with protection checks. Use `-s` only when intentionally skipping those checks.
+After a successful push, GitButler also synchronizes PR targets and stack descriptions for the
+selected branch and its ancestors. A forge update failure is reported as a warning; it does not
+turn the completed Git push into a failure.
+
+### `but pull`
+
+Update applied branches onto the latest target branch changes (usually `main`).
+Use this for "get latest from main" in a GitButler workspace.
+
+```bash
+but pull                      # Fetch and rebase applied branches
+but pull --check              # Dry-run preview: report what would happen, change nothing
+```
+
+Run `but pull` directly for a straightforward update; its output reports the result and `but undo`
+reverts it. Use `--check` first when the user or repository policy requires a preview without
+updating.
+Do not use raw `git pull` or `git rebase`.
+
+### `but pr`
+
+Create and manage pull requests.
+
+```bash
+but pr new <branch-selector> -m "Title..."        # Push branch and create PR (recommended); first message line is title, rest is description
+but pr new <branch-selector> -F pr_message.txt    # Use file: first line is title, rest is description
+but pr new <branch-selector> -t     # Use default content (commit message), skip prompts
+but pr new <branch-selector> --draft  # Create as draft
+but pr new <branch-selector> --no-hooks  # Bypass pre-push hooks (--no-verify also works)
+but pr new <branch-selector> -s     # Skip force-push protection checks
+but pr --draft                # Top-level draft flag
+but pr auto-merge <selector>  # Enable auto-merge
+but pr set-draft <selector>   # Mark review as draft
+but pr set-ready <selector>   # Mark review as ready
+```
+
+**Key behavior:** `but pr new` automatically pushes the selected branch and its ancestors before creating the PR. No need to run `but push` first. Force push and pre-push hooks run by default.
+Use `--no-hooks` to bypass pre-push hooks when needed.
+Review creation remains successful if the follow-up stack synchronization fails, and reports that
+partial success as a warning.
+
+Selectors for `auto-merge`, `set-draft`, and `set-ready` can be branch names, branch IDs, stack IDs, or numeric review IDs, comma-separated.
+
+Agents must use `--message (-m)`, `--file (-F)`, or `--default (-t)` to avoid editor prompts. The `-t` flag uses the commit message as title/description for single-commit branches; for multi-commit branches it falls back to the branch name as the title.
+
+**Stacked branches:** Use `but pr` for stacked PRs. It creates reviews against the right bases and updates GitButler stack footers in PR descriptions. Creating stacked PRs with `gh pr create` or another forge tool loses that stack-aware behavior. To publish a whole stack, run `but pr new <top-branch-name> -t`; custom messages (`-m` or `-F`) only apply to the selected branch, while dependent branches use default messages (commit title/description).
+
+When the selected branch sits on dependencies that already have PRs, the summary lists those as "PR already exists for ..." and ends with the newly created review. The already-exists lines are normal stack reporting, not a failure to create the selected branch's PR.
+
+Requires forge integration to be configured via `but config forge auth`.
+
+Same-repository pull requests are automatically registered with GitHub's native stacked pull
+requests API when the repository is enrolled in GitHub's private preview; otherwise GitButler uses
+description footers. `but config forge github-stacks disable` opts out. The setting is
+project-local and shared with Desktop.
+
+### `but land <branch>`
+
+Land a branch directly onto the target (e.g. `origin/master`), skipping a pull request. Fast-forwards
+when possible, otherwise makes a signed merge commit; for a `gb-local` target it moves the refs
+locally. Then reconciles the remaining branches like `but pull`, and deletes each landed branch's
+copy on the push remote (only when fully contained in the landed target), reported as
+`Deleted <remote>/<branch> (landed)`.
+
+```bash
+but land <branch-selector> --yes                  # Land onto the target (--yes required non-interactively)
+but land <branch-selector> --no-ff --yes          # Force a merge commit instead of fast-forwarding
+but land <top-branch> --whole-stack --yes   # Land an entire stack by naming its top segment
+```
+
+Direct target updates are hard to reverse, so confirmation is required (agents must pass `--yes`).
+A branch stacked on other segments is refused (its tip would also publish them); `--whole-stack`
+is the explicit opt-in, and only the stack's top segment can be named with it.
+
+## Workspace Maintenance
+
+### `but clean`
+
+Remove empty branches from the workspace.
+
+```bash
+but clean                   # Delete all empty branches
+but clean --dry-run         # Preview which branches would be deleted
+but clean --pull            # Pull latest changes first, then clean
+but clean --include-upstream # Also remove branches with upstream-only commits
+```
+
+A branch is considered empty if it has no local commits and no assigned changes. Branches with upstream-only commits are preserved by default unless `--include-upstream` is used.
+
+The entire operation is a single oplog entry — use `but undo` to restore all deleted branches.
+
+### `but worktree`
+
+Manage linked git worktrees (experimental worktree flag). `but wt` is a default alias.
+
+```bash
+but worktree list                 # Active worktrees with IDs, plus the 3 most recent archived ones
+but worktree list --archived      # All archived worktrees (`--active` for all active ones)
+but worktree archive <id|name>    # Hide a worktree from the workspace
+but worktree unarchive <name>     # Show it again; archived worktrees have no ID
+but worktree remove [-f] <id|name> # Like `git worktree remove`; `-f` for uncommitted changes
+```
+
+Worktrees are listed most recently updated first, as `id name (refs/heads/branch) - path`, with the branch shown only when it differs from the worktree name. Archiving is a GitButler-only state; none of these take part in `but undo`.
+
+## History & Undo
+
+### `but undo` / `but redo`
+
+Undo or redo operations.
+
+```bash
+but undo
+but redo
+```
+
+### `but oplog`
+
+View operation history.
+
+```bash
+but oplog
+but oplog list --since <snapshot-id>
+but oplog list --snapshot
+but oplog snapshot -m "known good"
+```
+
+Shows all operations with snapshot IDs.
+
+### `but oplog restore <snapshot>`
+
+Restore to a specific oplog snapshot.
+
+```bash
+but oplog restore <snapshot-id>
+```
+
+## Setup & Configuration
+
+### `but setup`
+
+Initialize GitButler in current git repository.
+
+```bash
+but setup
+but setup --init              # Also initialize a new git repo if none exists
+```
+
+Converts a regular Git repository to the managed GitButler workspace model. Use `--init` in
+non-interactive environments (CI/CD) to ensure a Git repository exists before setup. When the
+experimental single-branch feature is enabled, normal CLI use does not require this command: the
+repository is registered and its target is inferred lazily without checking out
+`gitbutler/workspace` or installing setup hooks.
+
+Rerunning `but setup` on an already-configured project also repairs a missing default target — for
+example if `virtual_branches.toml` was reset while the target survived in Git config — so it is the
+recovery path when target configuration looks broken.
+
+### `but teardown`
+
+Exit GitButler mode and return to normal git workflow.
+
+```bash
+but teardown
+```
+
+### `but config`
+
+View and manage GitButler configuration.
+
+```bash
+but config
+but config user               # Also: forge, target, metrics, feature, ui, ai
+but config ai openai          # Also: anthropic, ollama, lmstudio, openrouter
+but config target             # Show the current target branch
+but config target origin/main # Set the fetch target
+but config push-remote         # Show the current push remote
+but config push-remote origin  # Set the push remote without changing the target
+but config feature                         # List configurable feature flags
+but config feature single-branch           # Show a feature flag's value
+but config feature single-branch enable    # Also: disable
+```
+
+### `but update check`
+
+Manage GitButler CLI and app updates.
+
+```bash
+but update check
+but update install
+but update install [nightly|release|0.18.7]
+```
+
+### `but skill`
+
+Manage installed GitButler skill files.
+
+```bash
+but skill check
+but skill check --update
+but skill install --detect
+```
+
+## Selected Options
+
+Useful to agents:
+
+- `-C, --current-dir <PATH>` - Run as if started in different directory
+- `-h, --help` - Show help for command. Avoid routine help probes; use this reference first.
+
+## External commands (PATH helpers)
+
+> Important: Not available for Windows yet
+
+Similar to Git, if `<command>` is not a built-in `but` command and `but-<command>` exists on `PATH`, `but` runs that executable instead (for example `but forecast …` invokes `but-forecast …`).
+
+Restriction: `<command>` must consist of characters in the set `[a-zA-Z_-]`
+
+## Getting More Help
+
+```bash
+but --help                    # List all commands
+but <subcommand> --help       # Detailed help for specific command
+```
+
+Prefer this reference over exploratory help calls. Use command-specific help when required syntax
+is missing or a command fails; use top-level help only to discover an undocumented command.
+
+Full documentation: <https://docs.gitbutler.com/cli-overview>

--- a/.claude/skills/sops-secrets/SKILL.md
+++ b/.claude/skills/sops-secrets/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: sops-secrets
+description: SOPS/Age secret management for this repo. Use when creating, editing, encrypting, or verifying encrypted secrets. Trigger keywords: secret, sops, age, encrypt, decrypt, *.sops.yaml.
+---
+
+# SOPS/Age secrets
+
+All secrets in this repo are encrypted with SOPS using Age.
+
+## Rules
+
+- **NEVER** commit unencrypted secrets. The CI and pre-commit hooks will reject them.
+- Secret files are named `*.sops.yaml` (e.g., `externalsecret.sops.yaml`, `helmrelease.sops.yaml`)
+- The `age.key` file at the repo root must NEVER be committed (it's in `.gitignore` but verify before staging)
+- Unencrypted temp files with real secrets must never be committed
+
+## Workflow
+
+### Creating a new secret
+
+1. Create the file as a plain YAML with the `.sops.yaml` extension
+2. Run `just configure` — this auto-encrypts the file with SOPS
+3. Verify it's encrypted: check that the file starts with `sops:` or has `encrypted_regex` entries
+
+### Editing an existing secret
+
+1. Decrypt with `sops -d <file>` to read the content (read-only; do not write the decrypted output)
+2. Use `just configure` to re-encrypt after making changes
+3. Alternatively, use `sops <file>` which opens in an editor and encrypts on save — but the agent should NOT do this interactively
+
+### Verifying before commit
+
+Before committing, verify all staged `*.sops.yaml` files are encrypted:
+
+```bash
+# Check that sops files are actually encrypted
+for f in $(git diff --cached --name-only -- '*.sops.yaml'); do
+  head -1 "$f" | grep -q '^sops:' || echo "UNENCRYPTED: $f"
+done
+```
+
+If any file shows as UNENCRYPTED, run `just configure` to fix it.
+
+## Other encryption
+
+- `.sops.yaml` is the SOPS config file at the repo root — it defines which files are encrypted and with which key
+- `age.key` at repo root is the local Age private key — never commit, never share

--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,9 @@ talosconfig
 .private/
 .task/
 .venv/
-.opencode/skills/cloudflare/
 .DS_Store
 Thumbs.db
 
-.opencode/skills/cloudflare/SKILL.md
-.claude
+# Claude Code - track agents/skills/commands, ignore local state
+.claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,2 @@
 README.md
+.claude/skills/gitbutler/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Home-ops IaC repo — Kubernetes cluster managed with Flux CD, Talos Linux, and 
 
 ## Project model
 
-opencode/AI works as the **medior developer** — it implements changes, validates them, and presents PRs for review. The human maintainer is the **senior** — reviews code, runs final checks, and merges approved PRs.
+Claude works as the **medior developer** — it implements changes, validates them, and presents PRs for review. The human maintainer is the **senior** — reviews code, runs final checks, and merges approved PRs.
 
 - AI **does**: write code, run validation, create commits via `but`, open PRs via GitHub MCP tools (`github_create_pull_request`), check konflate blast radius, report cautions.
 - AI **does not**: merge PRs, push to `main` directly, approve its own changes, skip validation hooks, run auto-merge, or merge without explicit human approval.
@@ -54,7 +54,10 @@ opencode/AI works as the **medior developer** — it implements changes, validat
 
 ## Commits and PRs
 
-Use GitButler CLI (`but`) for all version control writes (commits, branches, pushes). Delegate VCS to the gitbutler skill for command detail. Use GitHub MCP tools (`github_create_pull_request`, `github_issue_write`, etc.) for all GitHub API operations. Never use `git add`, `git commit`, `git push`, or `gh pr create` for write operations. Never force-push, never skip hooks.
+Use GitButler CLI (`but`) for all version control writes (commits, branches, pushes). Delegate VCS to the
+gitbutler skill for command detail. Use GitHub MCP tools (`github_create_pull_request`,
+`github_issue_write`, etc.) for all GitHub API operations. Never use `git add`, `git commit`, `git push`,
+or `gh pr create` for write operations. Never force-push, never skip hooks.
 
 ### Before committing
 
@@ -65,7 +68,7 @@ Use GitButler CLI (`but`) for all version control writes (commits, branches, pus
 
 ### Making commits
 
-- Use `but commit <branch> -c -m "<msg>" --changes <ids>` to create a branch and commit in one step.
+- Use `but commit -b <branch> -m "<msg>" <ids>` to create a branch and commit in one step.
 - Use file/hunk IDs from `but diff` — never stage blindly.
 - Write concise, imperative-mood commit messages matching the existing repo style.
 
@@ -86,7 +89,7 @@ Use GitButler CLI (`but`) for all version control writes (commits, branches, pus
 
 ### Creating issues
 
-For bugs, tech debt, or tasks outside a PR workflow, create a GitHub issue. The GitHub MCP server (`github` tool prefix) is configured in `.opencode/opencode.json` — use its structured tools for issue operations.
+For bugs, tech debt, or tasks outside a PR workflow, create a GitHub issue. Use the `github` MCP server's structured tools for issue operations.
 
 - `github_issue_write` with `method: "create"` — Create a new issue with title, body, labels, assignees.
 - `github_search_issues` / `github_list_issues` — Find existing issues.
@@ -124,8 +127,13 @@ The `.github/workflows/auto-merge.yaml` workflow runs daily at 02:00 UTC and app
 - **Sleep between merges:** 300 seconds to let Flux reconcile before the next merge.
 - Konflate re-render is triggered before each merge gate via `KONFLATE_PUSH_TOKEN`.
 - **Bulk merge** (`.github/workflows/bulk-merge-prs.yaml`) also excludes rook-ceph, `area/talos`, `type/major`, `type/minor`, and `hold`.
-- **Defense in depth:** The `pr-classify` workflow applies `needs-review` and `risk/critical` labels to critical-infra PRs. Auto-merge hard-skips any PR with the `needs-review` label regardless of the title/branch regex — two independent detection layers must both fail for a critical upgrade to auto-merge.
-- **Konflate** is reachable only from inside the home network (private IP). From GitHub Actions, the konflate gate is skipped — the auto-merge relies on label/age/day rules alone. `Konflate` as a required status check in branch protection won't work from outside the network.
+- **Defense in depth:** The `pr-classify` workflow applies `needs-review` and `risk/critical` labels to
+  critical-infra PRs. Auto-merge hard-skips any PR with the `needs-review` label regardless of the
+  title/branch regex — two independent detection layers must both fail for a critical upgrade to
+  auto-merge.
+- **Konflate** is reachable only from inside the home network (private IP). From GitHub Actions, the
+  konflate gate is skipped — the auto-merge relies on label/age/day rules alone. `Konflate` as a
+  required status check in branch protection won't work from outside the network.
 - **Konflate write-back** posts a summary PR comment + commit status after each render when reachable (inside the network).
 - **Setup:** add `KONFLATE_PUSH_TOKEN` (random 32-byte hex) to 1Password `konflate` item and as a GitHub Actions secret; confirm the GitHub App has `checks: write` + `pull-requests: write` permissions.
 
@@ -155,24 +163,50 @@ Required WAF rules for the `juno.moe` zone (effective only when DNS records are 
 - Exporters (node-exporter, kube-state-metrics, smartctl-exporter, etc.) run locally, scraped by Alloy via ServiceMonitors.
 - Credentials stored in 1Password as `observability-vm` (Prometheus URL/user, Loki URL/user, API token).
 
-## opencode agents and skills
+## Claude Code agents, skills, and commands
 
-This project has opencode agents and skills configured in `.opencode/` to speed up common tasks.
+This project ships its Claude Code configuration in `.claude/` (tracked in git, so it is reviewed
+like any other change). `CLAUDE.md` at the repo root imports this file, so everything below loads
+automatically at session start.
 
-### Agents (`.opencode/agent/`)
+### Agents (`.claude/agents/`)
 
-- **cloudflare** — Cloudflare API ops for `juno.moe` zone: DNS, WAF rules, tunnel, Workers. Uses the globally installed Cloudflare MCP servers (cloudflare_docs, cloudflare_search, cloudflare_execute).
-- **gitops** — Flux/Kustomize manifest work: repo layout, validation pipeline, konflate PR review, SOPS rules.
-- **talos** — Talos Linux node operations: talosctl, patch regen, tuppr upgrades, OOM diagnostics.
+- **cluster-radar** — Read-only live-cluster investigator. Triages via the radar MCP server
+  (`issues` → `diagnose` → `get_events` → `get_changes` → logs) and falls back to
+  `kubectl`/`flux`/`talosctl` when radar is unavailable. It never mutates the cluster — fixes come
+  back as manifest changes so they land through Flux.
+- **grafana-logs** — Loki and Prometheus query agent. Holds the datasource UIDs and Loki label
+  schema, grinds through log volume in its own context, and returns a summary plus a Grafana
+  deeplink instead of raw lines.
+- **ship** — Runs the full validation chain, commits with `but`, pushes, and opens the PR via the
+  GitHub MCP server. It cannot merge — that capability is deliberately withheld.
 
-### Skills (`.opencode/skills/`)
+Delegate to these rather than doing cluster or log investigation inline: their output stays out of
+the main context window.
 
-- **cloudflare** — How to use the Cloudflare MCP tools with zone specifics (WAF table, tunnel, DNS).
+### Skills (`.claude/skills/`)
+
+- **gitbutler** — GitButler CLI (`but`) reference: commits, hunk selection, stacks, history edits.
 - **flux-validate** — The five-step validation pipeline in order with common failures and fixes.
 - **sops-secrets** — SOPS/Age encryption workflow for creating and verifying `*.sops.yaml` files.
 
-### Commands (`.opencode/command/`)
+The Cloudflare skills come from the `cloudflare` plugin marketplace, enabled in
+`.claude/settings.json`.
 
-- `/validate` — Run the full validation chain (`just configure` → `just validate` → `just flate-test` → `find_mistakes.py` → `pre-commit`).
+### Commands (`.claude/commands/`)
 
-**Restart opencode after changing any file in `.opencode/`** — config is loaded at startup only.
+- `/validate` — Run the full validation chain (`just configure` → `just validate` → `just flate-test`
+  → `find_mistakes.py` → `pre-commit`).
+- `/triage [namespace|app]` — Cluster health sweep via the cluster-radar agent.
+- `/ship [description]` — Validate, commit, push, and open a PR via the ship agent.
+
+### MCP servers
+
+- **radar** — `http://localhost:49412/mcp`, served by Radar.app. **Radar.app must be running**, or
+  every radar tool fails; agents fall back to `kubectl`/`flux` and say so.
+- **grafana** — points at `grafana.juno.moe`. Datasources: Prometheus `PBFA97CFB590B2093`,
+  Loki `P8E80F9AEF21F6940`.
+- **github** — repository, issue, and pull request operations.
+
+These are configured per-project in `~/.claude.json`, not in the repo, because the Grafana service
+account token would otherwise be committed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# home-ops
+
+Kubernetes homelab managed with Flux CD, Talos Linux, and SOPS/Age. The full working agreement —
+validation pipeline, commit and PR rules, auto-merge policy, cluster topology — is imported below.
+
+## Start here
+
+Delegate rather than investigating inline. Cluster state and log volume belong in a subagent's
+context, not this one:
+
+| Need | Use |
+|---|---|
+| Why is something broken in the cluster right now? | `cluster-radar` agent, or `/triage [namespace]` |
+| What do the logs or metrics say over time? | `grafana-logs` agent |
+| Validate, commit, and open a PR | `ship` agent, or `/ship [description]` |
+| Just run the validation chain | `/validate` |
+
+Before writing manifests, read the `flux-validate` skill for the validation pipeline and
+`sops-secrets` before touching any `*.sops.yaml`. Use `but` for every version control write — see
+the `gitbutler` skill — never `git add`, `git commit`, or `git push`.
+
+@AGENTS.md


### PR DESCRIPTION
## What

Sets up Claude Code for this repo and puts the config under review in git.

**New `CLAUDE.md` (root)** — a thin "Start here" delegation table naming the agents and commands, ending with `@AGENTS.md`. The import keeps a single source of truth rather than duplicating guidance.

**New `.claude/agents/`** — three subagents:

- `cluster-radar` — read-only live-cluster investigator over the radar MCP server. 23 read tools; all 7 mutating radar tools (`apply_resource`, `patch_resource`, `manage_workload`, `manage_node`, `manage_gitops`, `manage_cronjob`, `manage_rollout`) are deliberately left out of its `tools:` list, so cluster changes have to go through Flux.
- `grafana-logs` — Loki/Prometheus queries with datasource UIDs and the Loki label schema baked in. `model: sonnet`, read-only Grafana tools only.
- `ship` — validation chain, `but` commit, PR via the GitHub MCP server. `merge_pull_request` is withheld from its tool list.

**New `.claude/commands/`** — `/validate`, `/triage`, `/ship`.

**`.gitignore`** — `.claude` was previously ignored wholesale, so the skills were untracked and unreviewable. Now tracks `agents/`, `skills/`, and `commands/` while still ignoring `.claude/settings.local.json` and `.claude/scheduled_tasks.lock`. Also drops two dead `.opencode/skills/cloudflare/` lines.

**`AGENTS.md`** — removed all 9 references to `.opencode/`, a directory that no longer exists, and replaced the stale "opencode agents and skills" section with one describing `.claude/`. Rewrapped 3 pre-existing over-length (>240 char) lines to keep the file within the repo's markdownlint rules.

**`.markdownlintignore`** — added `.claude/skills/gitbutler/`. That is a vendored upstream GitButler skill (v0.22.2) with ~49 over-length lines that would otherwise violate MD013.

**New tracked `.claude/settings.json`** — read-only permissions allowlist (`kubectl get/describe/logs/top`, `flux get`, `talosctl get/health`, `just` read recipes, `pre-commit run`, `but status/diff/show/log`). `settings.local.json` is emptied, since its one entry moved into the tracked file.

## Why

Claude Code never loaded `AGENTS.md`. It only auto-loads `CLAUDE.md`, which did not exist here, so roughly 12KB of guidance — the validation pipeline, commit and PR rules, the auto-merge policy, cluster topology — was invisible every single session. Adding `CLAUDE.md` with an `@AGENTS.md` import fixes the loading problem without forking the content.

The `.gitignore` change is the other half: with `.claude` ignored outright, the agent and skill definitions that shape how an assistant operates on this cluster were never visible in review. They are configuration, and they should go through the same PR gate as everything else.

## Risk

**Low — tooling configuration only.** No Kubernetes manifests, no Talos config, no cluster state is touched. Nothing under `kubernetes/` or `talos/` changed, so Flux has nothing to reconcile and nothing restarts. No namespaces, storage, networking, or RBAC are affected. No Ceph or rook-ceph changes are included.

Konflate ran and passed. It renders manifest diffs, and this PR changes zero manifests, so it had nothing to report.

Three things worth a look during review, all slightly beyond the literal task:

- `AGENTS.md` line 71 documented the commit command with a `--changes` flag. That flag does not exist — the vendored gitbutler skill in this same PR explicitly names it as invented, alongside `--hunk` and `--ids`. Corrected to the real form, `but commit -b BRANCH -m "MSG" IDS`. This mattered here precisely because the PR is what makes `AGENTS.md` load: the wrong command would have become live guidance that fails on first use.
- The new MCP section said "Both are configured per-project" while listing three servers. Changed to "These".
- **The MegaLinter workflow is `disabled_manually` in this repo and did not run on this PR.** The markdown lint reasoning above is therefore a precaution, verified locally rather than by CI (details below). Worth deciding separately whether MegaLinter should be re-enabled — that is out of scope here.

## Validation

Run against the rebased tip of `main`. The workspace was 7 commits behind and still held `al-branch-189`, which had already landed upstream; `but pull` cleared both before committing, so the diff is against current `main`.

| Step | Result |
|---|---|
| `just configure` | **Did not run** — see below |
| `just validate` | exit 0 |
| `just flate-test` | exit 0, 169/169 passed |
| `python3 scripts/find_mistakes.py` | exit 0, 2 known pre-existing warnings |
| `pre-commit run --all-files` | exit 0, all 10 hooks passed, nothing reformatted |

`just configure` fails on this machine with `.venv/bin/makejinja: No such file or directory`. This is a pre-existing local environment problem, not something this PR caused: `.venv/` is untracked and gitignored, the recipe fails on its first line before touching anything, and this change contains no YAML, no templates, and no Python. `makejinja` does exist at `~/Library/Python/3.9/bin/makejinja`; the repo-local venv is a stub containing only `pip` and `wheel`. I did not repair it, since it is outside the repo and unrelated to this change — flagging it rather than silently working around it. Its meaningful sub-step, `yayamlls validate kubernetes/`, is exactly `just validate` and ran green; its other sub-step re-encrypts `*.sops.yaml`, and this PR contains none.

Because `pre-commit run --all-files` only covers files git already tracks, it was also run explicitly against every new `.claude/` file and `CLAUDE.md` — including gitleaks — which passed. The commit was checked to contain no `*.sops.yaml` files.

Since MegaLinter is disabled and could not check this, markdownlint was run locally over the new and modified markdown using the repo's own `.github/linters/.markdownlint.yaml`: zero errors, and the `.markdownlintignore` entry correctly suppresses the vendored gitbutler skill. The only rule that fires is MD060, which also fires on pre-existing `AGENTS.md` tables on `main` today, so it is not a regression from this PR.

`yayamlls` prints two `schema load failed` messages for `token.sops.yaml` and `ceph-secrets.sops.yaml`, from an upstream `LeShaunJ/ops-schema` URL that returns a non-JSON body. Known noise, non-fatal, still exits 0.

CI on the PR: 6 checks passed, `Flate - Test` correctly skipped (no manifest changes).

https://claude.ai/code/session_01SYhRgSkxMXXtRzexXrjeSZ