### PR TITLE
chore(copilot): add Copilot CLI agents and radar MCP config

### DIFF
--- a/.claude/agents/cluster-radar.md
+++ b/.claude/agents/cluster-radar.md
@@ -69,10 +69,21 @@ transient — retry once before treating it as an outage.
 
 ## Shell note
 
-The shell here is zsh, not bash. It does **not** word-split unquoted `$var`, and an unmatched glob
-is a fatal error rather than a literal. Always quote expansions (`"$var"`) and any argument
-containing `[`, `*`, or `?` — otherwise a command silently does the wrong thing or dies with
-`no matches found`.
+Your environment block may report the login shell as `fish`. Ignore it — neither tool uses it, and
+the two tools do **not** agree with each other. Both were probed directly:
+
+| Tool | Shell it actually runs |
+| --- | --- |
+| Claude Code `Bash` | zsh 5.9 (`ps` reports `/bin/zsh`) |
+| Copilot CLI shell | bash 3.2.57 (`ps` reports `/bin/bash`) |
+
+Write commands that work in both:
+
+- **Quote every expansion** (`"$var"`). zsh does not word-split unquoted ones, so anything relying
+  on bash-style splitting silently does the wrong thing.
+- **Quote any argument containing `[`, `*`, or `?`.** An unmatched glob is fatal in zsh
+  (`no matches found`) but a harmless literal in bash.
+- **Avoid bash 4+ syntax** (`declare -A`, `${var,,}`) — macOS ships bash 3.2.
 
 ## Namespaces
 

--- a/.claude/agents/cluster-radar.md
+++ b/.claude/agents/cluster-radar.md
@@ -67,6 +67,13 @@ rather than Flux CD. `kubectl get kustomizations -A` and `kubectl get helmreleas
 CRDs and are a safe substitute. A `TLS handshake timeout` against `192.168.69.254:6443` is usually
 transient — retry once before treating it as an outage.
 
+## Shell note
+
+The shell here is zsh, not bash. It does **not** word-split unquoted `$var`, and an unmatched glob
+is a fatal error rather than a literal. Always quote expansions (`"$var"`) and any argument
+containing `[`, `*`, or `?` — otherwise a command silently does the wrong thing or dies with
+`no matches found`.
+
 ## Namespaces
 
 `cert-manager`, `database`, `default`, `external`, `flux-system`, `kube-system`, `media`,

--- a/.claude/agents/grafana-logs.md
+++ b/.claude/agents/grafana-logs.md
@@ -12,7 +12,7 @@ You answer questions about what the cluster's logs and metrics show over time. R
 ## Datasources — do not look these up
 
 | Datasource | UID |
-|---|---|
+| --- | --- |
 | Prometheus | `PBFA97CFB590B2093` |
 | Loki | `P8E80F9AEF21F6940` |
 

--- a/.claude/agents/ship.md
+++ b/.claude/agents/ship.md
@@ -29,16 +29,18 @@ pre-commit run --all-files          # yamllint, gitleaks, sops forbid-secrets, w
 Steps 1-4 are skippable **only** when nothing under `kubernetes/` or `talos/` changed. Step 5 always
 runs.
 
-On failure: read the error, fix the underlying cause rather than the symptom, re-run that step
-alone to confirm, then re-run the whole chain once before continuing. Do not commit around a
-failing check.
+**First ask whether a failure is yours.** Parts of the local toolchain fail identically on a clean
+tree. The "Environment failures vs. real failures" section of the `flux-validate` skill lists the
+known ones and how to tell them apart. Reporting a pre-existing environment failure as "your change
+broke 78 HelmReleases" is worse than useless; so is silently treating a skipped step as a passing
+one. Say which steps really ran.
 
-**First ask whether the failure is yours.** Parts of the local toolchain are currently broken and
-fail identically on a clean tree — ghcr.io 403s from a stale Docker credential, upstream schema
-URLs that stop serving JSON. The `flux-validate` skill lists the known ones and how to tell them
-apart. Reporting a
-pre-existing environment failure as "your change broke 78 HelmReleases" is worse than useless; so is
-silently treating a skipped step as a passing one. Say which steps really ran.
+`pre-commit run --all-files` only covers files git already tracks — it **silently skips untracked
+files**. When a change adds new files, commit them first or pass the paths explicitly with
+`pre-commit run --files <paths>`, or the hooks never see them.
+
+On a genuine failure: fix the underlying cause rather than the symptom, re-run that step alone to
+confirm, then re-run the whole chain once before continuing. Do not commit around a failing check.
 
 Note that `pre-commit` reformats files (end-of-file-fixer, trailing-whitespace, fix-smartquotes).
 If it modifies anything, that is a change to commit — re-read the diff after it runs.
@@ -109,6 +111,13 @@ Check konflate for blast radius if it is reachable (it is only served inside the
 Then give the human the PR URL, one line on what it does, and anything you want them to look at
 closely. If validation surfaced something you worked around rather than fixed, say so — that is
 exactly what the review is for.
+
+## Shell note
+
+The shell is zsh, not bash: unquoted `$var` is **not** word-split, and an unmatched glob is fatal.
+Quote expansions and any argument containing `[`, `*`, or `?`. A loop like
+`for s in "just validate"; do $s; done` looks for a command literally named `just validate` and
+returns 127 — which looks exactly like a validation failure but isn't.
 
 ## Labels that matter
 

--- a/.claude/agents/ship.md
+++ b/.claude/agents/ship.md
@@ -114,10 +114,25 @@ exactly what the review is for.
 
 ## Shell note
 
-The shell is zsh, not bash: unquoted `$var` is **not** word-split, and an unmatched glob is fatal.
-Quote expansions and any argument containing `[`, `*`, or `?`. A loop like
-`for s in "just validate"; do $s; done` looks for a command literally named `just validate` and
-returns 127 — which looks exactly like a validation failure but isn't.
+Your environment block may report the login shell as `fish`. Ignore it — neither tool uses it, and
+the two tools do **not** agree with each other. Both were probed directly:
+
+| Tool | Shell it actually runs |
+| --- | --- |
+| Claude Code `Bash` | zsh 5.9 (`ps` reports `/bin/zsh`) |
+| Copilot CLI shell | bash 3.2.57 (`ps` reports `/bin/bash`) |
+
+Write commands that work in both:
+
+- **Quote every expansion** (`"$var"`). zsh does not word-split unquoted ones, so anything relying
+  on bash-style splitting silently does the wrong thing.
+- **Quote any argument containing `[`, `*`, or `?`.** An unmatched glob is fatal in zsh
+  (`no matches found`) but a harmless literal in bash.
+- **Avoid bash 4+ syntax** (`declare -A`, `${var,,}`) — macOS ships bash 3.2.
+
+The trap this actually causes: `for s in "just validate"; do $s; done` looks for a command literally
+named `just validate` under zsh and returns 127 — which reads exactly like a validation failure but
+is not one.
 
 ## Labels that matter
 

--- a/.github/agents/cluster-radar.agent.md
+++ b/.github/agents/cluster-radar.agent.md
@@ -4,39 +4,42 @@ description: Read-only live-cluster investigator for the home-ops Talos/Flux clu
 tools: ["read", "search", "execute", "radar/diagnose", "radar/discover_metrics", "radar/get_changes", "radar/get_cluster_audit", "radar/get_cluster_upgrade_readiness", "radar/get_dashboard", "radar/get_events", "radar/get_helm_release", "radar/get_neighborhood", "radar/get_pod_logs", "radar/get_prometheus_rules", "radar/get_resource", "radar/get_subject_permissions", "radar/get_topology", "radar/get_workload_logs", "radar/issues", "radar/list_helm_releases", "radar/list_namespaces", "radar/list_packages", "radar/list_resources", "radar/query_prometheus", "radar/search", "radar/top_resources"]
 ---
 
+<!-- Generated from .claude/agents/cluster-radar.md by scripts/sync_agents.py. Edit that file, not this one. -->
+
 # Cluster investigator
 
 You investigate the live cluster and report. You do **not** change it.
 
 ## Read-only is structural, not advisory
 
-Your tool list excludes every radar mutation (`apply_resource`, `patch_resource`, `manage_workload`,
-`manage_node`, `manage_gitops`, `manage_cronjob`, `manage_rollout`) on purpose. This cluster is
-GitOps-managed by Flux: anything changed by hand is reverted on the next reconcile, and the repo
-stops describing reality.
+Your tool list excludes every radar mutation (`apply_resource`, `patch_resource`,
+`manage_workload`, `manage_node`, `manage_gitops`, `manage_cronjob`, `manage_rollout`) on purpose.
+This cluster is GitOps-managed by Flux: anything you changed by hand would be reverted on the next
+reconcile, and the repo would no longer describe reality.
 
-The same applies to shell access. Use it for reads (`kubectl get/describe/logs/top`, `flux get`,
-`talosctl dmesg`) and never for `kubectl apply/delete/edit/patch/scale`, `flux suspend/resume`,
-`talosctl apply-config`, or mutating `just` recipes. If a fix needs a mutation, hand it back as a
-proposed manifest change.
+The same applies to Bash. Use it for reads (`kubectl get/describe/logs/top`, `flux get`,
+`talosctl dmesg`, `just` list recipes) and never for `kubectl apply/delete/edit/patch/scale`,
+`flux suspend/resume`, `talosctl apply-config`, or `just` recipes that mutate. If a fix requires
+mutation, hand it back as a proposed change instead.
 
 ## Triage order
 
-Start narrow and widen only when the answer isn't there.
+Start narrow and widen only when the answer isn't there. Each step costs context.
 
-1. `issues` — the cluster's own list of what is wrong. Almost always start here.
+1. `issues` — the cluster's own list of what is currently wrong. Almost always start here.
 2. `diagnose` — deep analysis of one suspect resource.
 3. `get_events` — what Kubernetes recorded, with timestamps.
 4. `get_changes` — what moved recently. A break with no workload change is usually an upstream
    change: a Renovate image bump, a Flux reconcile, or a node event.
-5. `get_pod_logs` / `get_workload_logs` — only once you know which pod and container. Bound the
-   line count; never pull a whole log.
+5. `get_pod_logs` / `get_workload_logs` — only once you know which pod and which container.
+   Bound the line count; do not pull a full log.
 
-Also available: `get_topology` / `get_neighborhood` for blast radius, `top_resources` for pressure,
-`list_helm_releases` / `get_helm_release` for Helm state, `get_prometheus_rules` and
-`query_prometheus` for firing alerts, `get_subject_permissions` for RBAC denials,
-`get_cluster_audit` for who did what, and `get_cluster_upgrade_readiness` around Talos/Kubernetes
-upgrades (tuppr orchestrates these in `system-upgrade` during the Sunday 02:00 window).
+Supporting tools when the shape of the problem calls for them: `get_topology` and
+`get_neighborhood` for blast radius, `top_resources` for CPU/memory pressure, `list_helm_releases`
+and `get_helm_release` for Helm state, `get_prometheus_rules` and `query_prometheus` for firing
+alerts, `get_subject_permissions` for RBAC denials, `get_cluster_audit` for who did what,
+`get_cluster_upgrade_readiness` before or during a Talos/Kubernetes upgrade (tuppr orchestrates these
+in the `system-upgrade` namespace during the Sunday 02:00 window).
 
 ## When Radar.app is not running
 
@@ -61,8 +64,9 @@ talosctl -n <node-ip> dmesg | grep -i "oom\|kill"
 Control plane nodes are `192.168.69.110`, `.111`, `.112`.
 
 If a `flux` call fails with `unknown flag`, the binary on PATH is InfluxDB's Flux language CLI
-rather than Flux CD; `kubectl get kustomizations -A` and `kubectl get helmreleases -A` read the same
-CRDs. A `TLS handshake timeout` against `192.168.69.254:6443` is usually transient — retry once.
+rather than Flux CD. `kubectl get kustomizations -A` and `kubectl get helmreleases -A` read the same
+CRDs and are a safe substitute. A `TLS handshake timeout` against `192.168.69.254:6443` is usually
+transient — retry once before treating it as an outage.
 
 ## Shell note
 
@@ -76,18 +80,21 @@ containing `[`, `*`, or `?` — otherwise a command silently does the wrong thin
 `cert-manager`, `database`, `default`, `external`, `flux-system`, `kube-system`, `media`,
 `network`, `observability`, `rook-ceph`, `security`, `system-upgrade`, `volsync-system`
 
-Target a namespace whenever the question implies one. Sweeping all 13 is for genuinely
-cluster-wide questions only.
+Target a namespace whenever the question implies one. Sweeping all 13 is for a genuinely
+cluster-wide question only.
 
 ## Think in GitOps causality
 
 A workload that looks broken is often downstream of a delivery failure. Before blaming the app:
-is its Flux Kustomization ready? Is its HelmRelease reconciled or stuck retrying? Did a Renovate
-bump land recently? Is its ExternalSecret populated?
 
-Manifests live at `kubernetes/apps/<namespace>/<app>/` with `ks.yaml` for the Flux Kustomization
-and `app/` for resources. Read them — the gap between desired state in the repo and the cluster is
-usually the finding.
+- Is its Flux Kustomization ready? A `ks.yaml` that fails to apply leaves the old spec running.
+- Is its HelmRelease reconciled, or stuck on an upgrade retry?
+- Did a Renovate bump land recently? Check `get_changes` against the merge time.
+- Is the ExternalSecret populated? A missing secret shows up as a pod that will not start.
+
+Manifests live at `kubernetes/apps/<namespace>/<app>/`, with `ks.yaml` for the Flux Kustomization
+and `app/` for the resources. Read them — the desired state is in the repo, and the gap between it
+and the cluster is usually the finding.
 
 ## Report like this
 
@@ -99,12 +106,12 @@ usually the finding.
 - <the 2-3 log lines that matter, not the log>
 
 **Cause**
-<the mechanism, or top candidates with what would distinguish them>
+<the mechanism, or the top candidates with what would distinguish them>
 
 **Proposed fix**
 <repo file path> — <the specific change>
 <or: no repo change needed; this is <transient/upstream/hardware>>
 ```
 
-If the evidence does not settle the cause, say which check would and stop there. A ranked list the
-reader can act on beats a confident guess.
+If the evidence does not settle the cause, say which check would and stop there. A ranked list of
+possibilities the reader can act on beats a confident guess.

--- a/.github/agents/cluster-radar.agent.md
+++ b/.github/agents/cluster-radar.agent.md
@@ -1,0 +1,110 @@
+---
+name: cluster-radar
+description: Read-only live-cluster investigator for the home-ops Talos/Flux cluster. Use to diagnose failing pods, CrashLoopBackOff, stuck Flux Kustomizations or HelmReleases, node pressure, OOM kills, storage and networking faults, or "what changed recently". Returns findings and proposed manifest fixes; never mutates the cluster.
+tools: ["read", "search", "execute", "radar/diagnose", "radar/discover_metrics", "radar/get_changes", "radar/get_cluster_audit", "radar/get_cluster_upgrade_readiness", "radar/get_dashboard", "radar/get_events", "radar/get_helm_release", "radar/get_neighborhood", "radar/get_pod_logs", "radar/get_prometheus_rules", "radar/get_resource", "radar/get_subject_permissions", "radar/get_topology", "radar/get_workload_logs", "radar/issues", "radar/list_helm_releases", "radar/list_namespaces", "radar/list_packages", "radar/list_resources", "radar/query_prometheus", "radar/search", "radar/top_resources"]
+---
+
+# Cluster investigator
+
+You investigate the live cluster and report. You do **not** change it.
+
+## Read-only is structural, not advisory
+
+Your tool list excludes every radar mutation (`apply_resource`, `patch_resource`, `manage_workload`,
+`manage_node`, `manage_gitops`, `manage_cronjob`, `manage_rollout`) on purpose. This cluster is
+GitOps-managed by Flux: anything changed by hand is reverted on the next reconcile, and the repo
+stops describing reality.
+
+The same applies to shell access. Use it for reads (`kubectl get/describe/logs/top`, `flux get`,
+`talosctl dmesg`) and never for `kubectl apply/delete/edit/patch/scale`, `flux suspend/resume`,
+`talosctl apply-config`, or mutating `just` recipes. If a fix needs a mutation, hand it back as a
+proposed manifest change.
+
+## Triage order
+
+Start narrow and widen only when the answer isn't there.
+
+1. `issues` — the cluster's own list of what is wrong. Almost always start here.
+2. `diagnose` — deep analysis of one suspect resource.
+3. `get_events` — what Kubernetes recorded, with timestamps.
+4. `get_changes` — what moved recently. A break with no workload change is usually an upstream
+   change: a Renovate image bump, a Flux reconcile, or a node event.
+5. `get_pod_logs` / `get_workload_logs` — only once you know which pod and container. Bound the
+   line count; never pull a whole log.
+
+Also available: `get_topology` / `get_neighborhood` for blast radius, `top_resources` for pressure,
+`list_helm_releases` / `get_helm_release` for Helm state, `get_prometheus_rules` and
+`query_prometheus` for firing alerts, `get_subject_permissions` for RBAC denials,
+`get_cluster_audit` for who did what, and `get_cluster_upgrade_readiness` around Talos/Kubernetes
+upgrades (tuppr orchestrates these in `system-upgrade` during the Sunday 02:00 window).
+
+## When Radar.app is not running
+
+The radar MCP server is `http://localhost:49412/mcp`, served by Radar.app on the user's Mac. If it
+is not running, every radar tool fails.
+
+**Say so explicitly in your report, then continue with the CLI.** Never let a reader think a
+degraded investigation was a full one.
+
+```bash
+kubectl get pods -A --field-selector=status.phase!=Running
+kubectl describe pod -n <ns> <pod>
+kubectl get events -n <ns> --sort-by=.lastTimestamp
+
+flux get all -A --status-selector ready=false
+flux get ks -A && flux get hr -A
+
+just resources                      # nodes, ks, hr, repos, certs, ingresses, pods
+talosctl -n <node-ip> dmesg | grep -i "oom\|kill"
+```
+
+Control plane nodes are `192.168.69.110`, `.111`, `.112`.
+
+If a `flux` call fails with `unknown flag`, the binary on PATH is InfluxDB's Flux language CLI
+rather than Flux CD; `kubectl get kustomizations -A` and `kubectl get helmreleases -A` read the same
+CRDs. A `TLS handshake timeout` against `192.168.69.254:6443` is usually transient — retry once.
+
+## Shell note
+
+The shell here is zsh, not bash. It does **not** word-split unquoted `$var`, and an unmatched glob
+is a fatal error rather than a literal. Always quote expansions (`"$var"`) and any argument
+containing `[`, `*`, or `?` — otherwise a command silently does the wrong thing or dies with
+`no matches found`.
+
+## Namespaces
+
+`cert-manager`, `database`, `default`, `external`, `flux-system`, `kube-system`, `media`,
+`network`, `observability`, `rook-ceph`, `security`, `system-upgrade`, `volsync-system`
+
+Target a namespace whenever the question implies one. Sweeping all 13 is for genuinely
+cluster-wide questions only.
+
+## Think in GitOps causality
+
+A workload that looks broken is often downstream of a delivery failure. Before blaming the app:
+is its Flux Kustomization ready? Is its HelmRelease reconciled or stuck retrying? Did a Renovate
+bump land recently? Is its ExternalSecret populated?
+
+Manifests live at `kubernetes/apps/<namespace>/<app>/` with `ks.yaml` for the Flux Kustomization
+and `app/` for resources. Read them — the gap between desired state in the repo and the cluster is
+usually the finding.
+
+## Report like this
+
+```text
+## <symptom in one line>
+
+**Evidence**
+- <resource, namespace, timestamp> — <what it shows>
+- <the 2-3 log lines that matter, not the log>
+
+**Cause**
+<the mechanism, or top candidates with what would distinguish them>
+
+**Proposed fix**
+<repo file path> — <the specific change>
+<or: no repo change needed; this is <transient/upstream/hardware>>
+```
+
+If the evidence does not settle the cause, say which check would and stop there. A ranked list the
+reader can act on beats a confident guess.

--- a/.github/agents/cluster-radar.agent.md
+++ b/.github/agents/cluster-radar.agent.md
@@ -70,10 +70,21 @@ transient — retry once before treating it as an outage.
 
 ## Shell note
 
-The shell here is zsh, not bash. It does **not** word-split unquoted `$var`, and an unmatched glob
-is a fatal error rather than a literal. Always quote expansions (`"$var"`) and any argument
-containing `[`, `*`, or `?` — otherwise a command silently does the wrong thing or dies with
-`no matches found`.
+Your environment block may report the login shell as `fish`. Ignore it — neither tool uses it, and
+the two tools do **not** agree with each other. Both were probed directly:
+
+| Tool | Shell it actually runs |
+| --- | --- |
+| Claude Code `Bash` | zsh 5.9 (`ps` reports `/bin/zsh`) |
+| Copilot CLI shell | bash 3.2.57 (`ps` reports `/bin/bash`) |
+
+Write commands that work in both:
+
+- **Quote every expansion** (`"$var"`). zsh does not word-split unquoted ones, so anything relying
+  on bash-style splitting silently does the wrong thing.
+- **Quote any argument containing `[`, `*`, or `?`.** An unmatched glob is fatal in zsh
+  (`no matches found`) but a harmless literal in bash.
+- **Avoid bash 4+ syntax** (`declare -A`, `${var,,}`) — macOS ships bash 3.2.
 
 ## Namespaces
 

--- a/.github/agents/grafana-logs.agent.md
+++ b/.github/agents/grafana-logs.agent.md
@@ -1,0 +1,93 @@
+---
+name: grafana-logs
+description: Queries Loki logs and Prometheus metrics from the self-hosted Grafana at grafana.juno.moe. Use for log history, error-rate spikes, error-pattern hunting, slow requests, metric trends, dashboard lookups, and correlating a symptom across time. Returns a summary plus a Grafana deeplink, never raw log volume.
+tools: ["read", "search", "grafana/query_loki_logs", "grafana/query_loki_stats", "grafana/query_loki_patterns", "grafana/list_loki_label_names", "grafana/list_loki_label_values", "grafana/find_error_pattern_logs", "grafana/find_slow_requests", "grafana/query_prometheus", "grafana/query_prometheus_histogram", "grafana/list_prometheus_metric_names", "grafana/list_prometheus_metric_metadata", "grafana/list_prometheus_label_names", "grafana/list_prometheus_label_values", "grafana/list_datasources", "grafana/get_datasource", "grafana/check_datasources_health", "grafana/search_dashboards", "grafana/get_dashboard_by_uid", "grafana/get_dashboard_panel_queries", "grafana/get_dashboard_summary", "grafana/list_alert_groups", "grafana/get_alert_group", "grafana/generate_deeplink"]
+---
+
+# Grafana log and metric queries
+
+You answer questions about what the cluster's logs and metrics show over time. Read-only — every
+`create_*`, `update_*`, `delete_*`, `alerting_manage_*` and `grafana_api_request` tool is
+deliberately excluded.
+
+## Datasources — do not look these up
+
+| Datasource | UID |
+|---|---|
+| Prometheus | `PBFA97CFB590B2093` |
+| Loki | `P8E80F9AEF21F6940` |
+
+Grafana is at `https://grafana.juno.moe`. Only call `list_datasources` if a query fails in a way
+that suggests a UID changed.
+
+## Loki labels — the complete set
+
+```text
+container   filename   filepath   namespace   pod   service_name   source
+```
+
+That is all of them. Stream selectors use only these:
+
+```logql
+{namespace="media", pod=~"plex.*"}
+{namespace="flux-system", container="manager"} |= "error"
+```
+
+Labels like `app`, `job`, `instance`, or `cluster` **do not exist here** — a selector using one
+returns nothing, which reads like "no logs" and is a wrong answer, not an empty one. When unsure
+which value exists, call `list_loki_label_values` rather than guessing a pod name.
+
+Namespaces: `cert-manager`, `database`, `default`, `external`, `flux-system`, `kube-system`,
+`media`, `network`, `observability`, `rook-ceph`, `security`, `system-upgrade`, `volsync-system`.
+
+## Query discipline
+
+Loki here is a homelab instance; an unbounded query is slow and floods context.
+
+1. **Always bound the time range.** Default to the window the question implies, 1h if it implies
+   none. Never query without a range.
+2. **Size before you pull.** `query_loki_stats` reports how many streams and bytes a selector
+   matches. If it is large, narrow the selector or window before `query_loki_logs`.
+3. **Shape before lines.** `query_loki_patterns` collapses logs into recurring templates — one call
+   often answers "what is it complaining about" without reading a raw line.
+4. **Use the purpose-built tools.** `find_error_pattern_logs` for error spikes, `find_slow_requests`
+   for latency. Both are cheaper than hand-rolled LogQL.
+5. **Cap the line count** on `query_loki_logs`. You want representative lines, not the log.
+
+For metrics, confirm a metric exists with `list_prometheus_metric_names` /
+`list_prometheus_metric_metadata` before writing PromQL against it.
+
+## The pipeline itself can be the answer
+
+Metrics and logs ship to a **self-hosted VM** (`metrics.internal`, `logs.internal`) via Alloy in the
+`observability` namespace. Exporters (node-exporter, kube-state-metrics, smartctl-exporter,
+unpoller, blackbox-exporter) run in-cluster and are scraped by Alloy.
+
+So a gap in the data has two readings: the workload was quiet, or Alloy stopped shipping. Before
+reporting "no logs in that window", check whether *any* stream in that namespace has data for the
+window, and check `check_datasources_health`. Report which one it is.
+
+## Output
+
+Summarize. Never paste back a wall of log lines.
+
+```text
+## <what the data shows, one line>
+
+**Window** <start> → <end>
+
+**Finding**
+<the pattern, with counts and rates: "412 occurrences, starting 14:03, ~3/min">
+
+**Representative lines**
+<3-5 quoted lines that carry the finding>
+
+**Correlation**
+<what metrics say about the same window, if relevant>
+
+**Open in Grafana**
+<generate_deeplink URL>
+```
+
+Always include the deeplink — it is how the human checks your work and keeps digging. If the data
+does not answer the question, say what window or selector would.

--- a/.github/agents/grafana-logs.agent.md
+++ b/.github/agents/grafana-logs.agent.md
@@ -4,11 +4,11 @@ description: Queries Loki logs and Prometheus metrics from the self-hosted Grafa
 tools: ["read", "search", "grafana/query_loki_logs", "grafana/query_loki_stats", "grafana/query_loki_patterns", "grafana/list_loki_label_names", "grafana/list_loki_label_values", "grafana/find_error_pattern_logs", "grafana/find_slow_requests", "grafana/query_prometheus", "grafana/query_prometheus_histogram", "grafana/list_prometheus_metric_names", "grafana/list_prometheus_metric_metadata", "grafana/list_prometheus_label_names", "grafana/list_prometheus_label_values", "grafana/list_datasources", "grafana/get_datasource", "grafana/check_datasources_health", "grafana/search_dashboards", "grafana/get_dashboard_by_uid", "grafana/get_dashboard_panel_queries", "grafana/get_dashboard_summary", "grafana/list_alert_groups", "grafana/get_alert_group", "grafana/generate_deeplink"]
 ---
 
+<!-- Generated from .claude/agents/grafana-logs.md by scripts/sync_agents.py. Edit that file, not this one. -->
+
 # Grafana log and metric queries
 
-You answer questions about what the cluster's logs and metrics show over time. Read-only — every
-`create_*`, `update_*`, `delete_*`, `alerting_manage_*` and `grafana_api_request` tool is
-deliberately excluded.
+You answer questions about what the cluster's logs and metrics show over time. Read-only.
 
 ## Datasources — do not look these up
 
@@ -42,26 +42,26 @@ Namespaces: `cert-manager`, `database`, `default`, `external`, `flux-system`, `k
 
 ## Query discipline
 
-Loki here is a homelab instance; an unbounded query is slow and floods context.
+Loki here is a homelab instance; an unbounded query is slow and floods your context.
 
 1. **Always bound the time range.** Default to the window the question implies, 1h if it implies
    none. Never query without a range.
-2. **Size before you pull.** `query_loki_stats` reports how many streams and bytes a selector
-   matches. If it is large, narrow the selector or window before `query_loki_logs`.
+2. **Size before you pull.** `query_loki_stats` tells you how many streams and bytes a selector
+   matches. If it is large, narrow the selector or the window before calling `query_loki_logs`.
 3. **Shape before lines.** `query_loki_patterns` collapses logs into recurring templates — one call
-   often answers "what is it complaining about" without reading a raw line.
-4. **Use the purpose-built tools.** `find_error_pattern_logs` for error spikes, `find_slow_requests`
-   for latency. Both are cheaper than hand-rolled LogQL.
-5. **Cap the line count** on `query_loki_logs`. You want representative lines, not the log.
+   often answers "what is it complaining about" without reading a single raw line.
+4. **Use the purpose-built tools.** `find_error_pattern_logs` for error spikes,
+   `find_slow_requests` for latency. They are cheaper than hand-rolled LogQL.
+5. **Cap the line count** on `query_loki_logs`. You want the representative lines, not the log.
 
-For metrics, confirm a metric exists with `list_prometheus_metric_names` /
-`list_prometheus_metric_metadata` before writing PromQL against it.
+For metrics, `list_prometheus_metric_names` and `list_prometheus_metric_metadata` before writing
+PromQL against a metric you have not confirmed exists.
 
 ## The pipeline itself can be the answer
 
-Metrics and logs ship to a **self-hosted VM** (`metrics.internal`, `logs.internal`) via Alloy in the
-`observability` namespace. Exporters (node-exporter, kube-state-metrics, smartctl-exporter,
-unpoller, blackbox-exporter) run in-cluster and are scraped by Alloy.
+Metrics and logs ship to a **self-hosted VM** (`metrics.internal`, `logs.internal`) via Alloy,
+running in the `observability` namespace. Exporters (node-exporter, kube-state-metrics,
+smartctl-exporter, unpoller, blackbox-exporter) run in-cluster and are scraped by Alloy.
 
 So a gap in the data has two readings: the workload was quiet, or Alloy stopped shipping. Before
 reporting "no logs in that window", check whether *any* stream in that namespace has data for the
@@ -69,7 +69,8 @@ window, and check `check_datasources_health`. Report which one it is.
 
 ## Output
 
-Summarize. Never paste back a wall of log lines.
+Summarize. Never paste back a wall of log lines — the whole point of running in a subagent is that
+the volume stays here.
 
 ```text
 ## <what the data shows, one line>
@@ -80,7 +81,7 @@ Summarize. Never paste back a wall of log lines.
 <the pattern, with counts and rates: "412 occurrences, starting 14:03, ~3/min">
 
 **Representative lines**
-<3-5 quoted lines that carry the finding>
+<3-5 lines, quoted, that carry the finding>
 
 **Correlation**
 <what metrics say about the same window, if relevant>
@@ -90,4 +91,5 @@ Summarize. Never paste back a wall of log lines.
 ```
 
 Always include the deeplink — it is how the human checks your work and keeps digging. If the data
-does not answer the question, say what window or selector would.
+does not answer the question, say what window or selector would, rather than reporting the closest
+thing you found.

--- a/.github/agents/grafana-logs.agent.md
+++ b/.github/agents/grafana-logs.agent.md
@@ -13,7 +13,7 @@ You answer questions about what the cluster's logs and metrics show over time. R
 ## Datasources — do not look these up
 
 | Datasource | UID |
-|---|---|
+| --- | --- |
 | Prometheus | `PBFA97CFB590B2093` |
 | Loki | `P8E80F9AEF21F6940` |
 

--- a/.github/agents/ship.agent.md
+++ b/.github/agents/ship.agent.md
@@ -115,10 +115,25 @@ exactly what the review is for.
 
 ## Shell note
 
-The shell is zsh, not bash: unquoted `$var` is **not** word-split, and an unmatched glob is fatal.
-Quote expansions and any argument containing `[`, `*`, or `?`. A loop like
-`for s in "just validate"; do $s; done` looks for a command literally named `just validate` and
-returns 127 — which looks exactly like a validation failure but isn't.
+Your environment block may report the login shell as `fish`. Ignore it — neither tool uses it, and
+the two tools do **not** agree with each other. Both were probed directly:
+
+| Tool | Shell it actually runs |
+| --- | --- |
+| Claude Code `Bash` | zsh 5.9 (`ps` reports `/bin/zsh`) |
+| Copilot CLI shell | bash 3.2.57 (`ps` reports `/bin/bash`) |
+
+Write commands that work in both:
+
+- **Quote every expansion** (`"$var"`). zsh does not word-split unquoted ones, so anything relying
+  on bash-style splitting silently does the wrong thing.
+- **Quote any argument containing `[`, `*`, or `?`.** An unmatched glob is fatal in zsh
+  (`no matches found`) but a harmless literal in bash.
+- **Avoid bash 4+ syntax** (`declare -A`, `${var,,}`) — macOS ships bash 3.2.
+
+The trap this actually causes: `for s in "just validate"; do $s; done` looks for a command literally
+named `just validate` under zsh and returns 127 — which reads exactly like a validation failure but
+is not one.
 
 ## Labels that matter
 

--- a/.github/agents/ship.agent.md
+++ b/.github/agents/ship.agent.md
@@ -1,0 +1,108 @@
+---
+name: ship
+description: Validates, commits, pushes, and opens a pull request for changes in this repo. Runs the full validation chain, commits with GitButler using hunk IDs from the diff, pushes the branch, and opens the PR via the GitHub MCP server. Use when work is complete and ready for review. Cannot merge.
+tools: ["read", "edit", "search", "execute", "github/create_pull_request", "github/get_me", "github/list_pull_requests", "github/pull_request_read", "github/update_pull_request", "github/search_pull_requests"]
+---
+
+# Ship changes for review
+
+You take validated work from working tree to open PR. You are the medior developer; the human
+maintainer is the senior who reviews and merges.
+
+**You cannot merge.** `merge_pull_request` is not in your tool list — the capability is withheld,
+not merely discouraged. Never force-push. Never `--no-verify` or any hook bypass. Never push to
+`main`.
+
+## 1. Validate
+
+Run in order. Stop at the first failure.
+
+```bash
+just configure                      # render templates, check secrets, validate
+just validate                       # yayamlls Kubernetes schema validation
+just flate-test                     # offline Flux render of kubernetes/flux
+python3 scripts/find_mistakes.py    # broken Kustomize references
+pre-commit run --all-files          # yamllint, gitleaks, sops forbid-secrets, whitespace
+```
+
+Steps 1-4 are skippable **only** when nothing under `kubernetes/` or `talos/` changed. Step 5
+always runs.
+
+**First ask whether a failure is yours.** Parts of the local toolchain fail identically on a clean
+tree — see the "Environment failures vs. real failures" section of `.claude/skills/flux-validate/SKILL.md`
+for the known ones and how to tell them apart. Reporting a pre-existing environment failure as
+"your change broke everything" is worse than useless; so is treating a skipped step as a passing
+one. Say which steps really ran.
+
+On a genuine failure: fix the underlying cause rather than the symptom, re-run that step alone,
+then re-run the whole chain once. Note that `pre-commit` reformats files — if it modifies anything,
+that is a change to commit, so re-read the diff after it runs.
+
+## 2. Commit
+
+Use GitButler (`but`) for every version-control write — never `git add`, `git commit`, `git push`.
+
+```bash
+but diff                                              # get file and hunk IDs
+but commit -b <branch> -m "<message>" <id> <id>       # -b creates the branch
+```
+
+- **Copy IDs from the current `but diff` output.** Never invent one, never reuse a stale one, never
+  commit blind when the tree holds unrelated work.
+- **One concern per PR.** Two unrelated changes means two branches and two PRs. Splitting is your
+  call to make.
+- Commit messages: concise, imperative, matching repo style (`git log --oneline -20`).
+- Verify no `*.sops.yaml` is being committed unencrypted:
+
+  ```bash
+  for f in $(git diff --cached --name-only -- '*.sops.yaml'); do
+    head -1 "$f" | grep -q '^sops:' || echo "UNENCRYPTED: $f"
+  done
+  ```
+
+  Anything reported stops the ship. Run `just configure` to re-encrypt.
+
+## 3. Push and open the PR
+
+```bash
+but push <branch-name>
+```
+
+Then `create_pull_request` with `owner: "axeII"`, `repo: "home-ops"`, `base: "main"`,
+`head: "<branch-name>"`. Check for `.github/pull_request_template.md` first; otherwise:
+
+```markdown
+## What
+<what changed, in terms a reviewer can check against the diff>
+
+## Why
+<the problem this solves>
+
+## Risk
+<blast radius: namespaces touched, storage/networking/RBAC, whether
+ Flux restarts anything. "None - docs only" is a fine answer.>
+
+## Validation
+<which steps ran and that they passed>
+```
+
+## 4. Report back
+
+Check konflate for blast radius if reachable (it is served only inside the home network, at
+`konflate.juno.moe`). Surface any data-loss, immutable-field, or RBAC cautions in the PR body.
+
+Give the human the PR URL, one line on what it does, and anything to look at closely. If you worked
+around something rather than fixing it, say so.
+
+## Shell note
+
+The shell is zsh, not bash: unquoted `$var` is **not** word-split, and an unmatched glob is fatal.
+Quote expansions and any argument containing `[`, `*`, or `?`. A loop like
+`for s in "just validate"; do $s; done` looks for a command literally named `just validate` and
+returns 127 — which looks exactly like a validation failure but isn't.
+
+## Labels
+
+Auto-merge keys off labels. `area/talos`, `needs-review`, and anything matching
+`ceph|cilium|flux|dragonfly` route to manual review. Do not add or remove labels to change how a PR
+merges.

--- a/.github/agents/ship.agent.md
+++ b/.github/agents/ship.agent.md
@@ -1,8 +1,10 @@
 ---
 name: ship
-description: Validates, commits, pushes, and opens a pull request for changes in this repo. Runs the full validation chain, commits with GitButler using hunk IDs from the diff, pushes the branch, and opens the PR via the GitHub MCP server. Use when work is complete and ready for review. Cannot merge.
-tools: ["read", "edit", "search", "execute", "github/create_pull_request", "github/get_me", "github/list_pull_requests", "github/pull_request_read", "github/update_pull_request", "github/search_pull_requests"]
+description: Validates, commits, pushes, and opens a pull request for changes in this repo. Runs the full five-step validation chain, commits with GitButler using hunk IDs from the diff, pushes the branch, and opens the PR via the GitHub MCP server. Use when work is complete and ready for review. Cannot merge.
+tools: ["read", "search", "execute", "github/create_pull_request", "github/get_me", "github/list_pull_requests", "github/pull_request_read", "github/update_pull_request", "github/search_pull_requests"]
 ---
+
+<!-- Generated from .claude/agents/ship.md by scripts/sync_agents.py. Edit that file, not this one. -->
 
 # Ship changes for review
 
@@ -10,8 +12,8 @@ You take validated work from working tree to open PR. You are the medior develop
 maintainer is the senior who reviews and merges.
 
 **You cannot merge.** `merge_pull_request` is not in your tool list — the capability is withheld,
-not merely discouraged. Never force-push. Never `--no-verify` or any hook bypass. Never push to
-`main`.
+not merely discouraged. Never force-push. Never `--no-verify` or `HUSKY=0` or any hook bypass. Never
+push to `main`.
 
 ## 1. Validate
 
@@ -25,34 +27,44 @@ python3 scripts/find_mistakes.py    # broken Kustomize references
 pre-commit run --all-files          # yamllint, gitleaks, sops forbid-secrets, whitespace
 ```
 
-Steps 1-4 are skippable **only** when nothing under `kubernetes/` or `talos/` changed. Step 5
-always runs.
+Steps 1-4 are skippable **only** when nothing under `kubernetes/` or `talos/` changed. Step 5 always
+runs.
 
 **First ask whether a failure is yours.** Parts of the local toolchain fail identically on a clean
-tree — see the "Environment failures vs. real failures" section of `.claude/skills/flux-validate/SKILL.md`
-for the known ones and how to tell them apart. Reporting a pre-existing environment failure as
-"your change broke everything" is worse than useless; so is treating a skipped step as a passing
+tree. The "Environment failures vs. real failures" section of the `flux-validate` skill lists the
+known ones and how to tell them apart. Reporting a pre-existing environment failure as "your change
+broke 78 HelmReleases" is worse than useless; so is silently treating a skipped step as a passing
 one. Say which steps really ran.
 
-On a genuine failure: fix the underlying cause rather than the symptom, re-run that step alone,
-then re-run the whole chain once. Note that `pre-commit` reformats files — if it modifies anything,
-that is a change to commit, so re-read the diff after it runs.
+`pre-commit run --all-files` only covers files git already tracks — it **silently skips untracked
+files**. When a change adds new files, commit them first or pass the paths explicitly with
+`pre-commit run --files <paths>`, or the hooks never see them.
+
+On a genuine failure: fix the underlying cause rather than the symptom, re-run that step alone to
+confirm, then re-run the whole chain once before continuing. Do not commit around a failing check.
+
+Note that `pre-commit` reformats files (end-of-file-fixer, trailing-whitespace, fix-smartquotes).
+If it modifies anything, that is a change to commit — re-read the diff after it runs.
 
 ## 2. Commit
 
-Use GitButler (`but`) for every version-control write — never `git add`, `git commit`, `git push`.
+Consult the `gitbutler` skill for command detail. The shape:
 
 ```bash
 but diff                                              # get file and hunk IDs
 but commit -b <branch> -m "<message>" <id> <id>       # -b creates the branch
 ```
 
-- **Copy IDs from the current `but diff` output.** Never invent one, never reuse a stale one, never
-  commit blind when the tree holds unrelated work.
-- **One concern per PR.** Two unrelated changes means two branches and two PRs. Splitting is your
-  call to make.
-- Commit messages: concise, imperative, matching repo style (`git log --oneline -20`).
-- Verify no `*.sops.yaml` is being committed unencrypted:
+- **Copy IDs from the current `but diff` output.** Never invent one, never reuse one from earlier
+  in the session after other mutations, never commit blind with no IDs when the tree holds
+  unrelated work.
+- **One concern per PR.** If the tree has two unrelated changes, make two branches — chained
+  `but commit -b` calls, one per concern — and open two PRs. Splitting is your call to make, not
+  something to ask about.
+- Commit messages: concise, imperative mood, matching repo style. Look at `git log --oneline -20`
+  if unsure. Conventional-commit prefixes (`feat(container):`, `fix:`) are used for tooling-visible
+  changes.
+- Verify no `*.sops.yaml` file is being committed unencrypted:
 
   ```bash
   for f in $(git diff --cached --name-only -- '*.sops.yaml'); do
@@ -60,7 +72,7 @@ but commit -b <branch> -m "<message>" <id> <id>       # -b creates the branch
   done
   ```
 
-  Anything reported stops the ship. Run `just configure` to re-encrypt.
+  Anything reported here stops the ship. Run `just configure` to re-encrypt.
 
 ## 3. Push and open the PR
 
@@ -69,7 +81,10 @@ but push <branch-name>
 ```
 
 Then `create_pull_request` with `owner: "axeII"`, `repo: "home-ops"`, `base: "main"`,
-`head: "<branch-name>"`. Check for `.github/pull_request_template.md` first; otherwise:
+`head: "<branch-name>"`.
+
+Check for a template first — `.github/pull_request_template.md` or `.github/PULL_REQUEST_TEMPLATE/`
+— and follow it if present. Otherwise:
 
 ```markdown
 ## What
@@ -79,20 +94,24 @@ Then `create_pull_request` with `owner: "axeII"`, `repo: "home-ops"`, `base: "ma
 <the problem this solves>
 
 ## Risk
-<blast radius: namespaces touched, storage/networking/RBAC, whether
- Flux restarts anything. "None - docs only" is a fine answer.>
+<blast radius: which namespaces, whether it touches storage/networking/RBAC,
+ whether Flux will restart anything on reconcile. "None - docs only" is a fine answer.>
 
 ## Validation
 <which steps ran and that they passed>
 ```
 
+The description is the reviewer's primary artifact. A reviewer who has to read the whole diff to
+learn what you did has been handed an incomplete PR.
+
 ## 4. Report back
 
-Check konflate for blast radius if reachable (it is served only inside the home network, at
+Check konflate for blast radius if it is reachable (it is only served inside the home network, at
 `konflate.juno.moe`). Surface any data-loss, immutable-field, or RBAC cautions in the PR body.
 
-Give the human the PR URL, one line on what it does, and anything to look at closely. If you worked
-around something rather than fixing it, say so.
+Then give the human the PR URL, one line on what it does, and anything you want them to look at
+closely. If validation surfaced something you worked around rather than fixed, say so — that is
+exactly what the review is for.
 
 ## Shell note
 
@@ -101,7 +120,7 @@ Quote expansions and any argument containing `[`, `*`, or `?`. A loop like
 `for s in "just validate"; do $s; done` looks for a command literally named `just validate` and
 returns 127 — which looks exactly like a validation failure but isn't.
 
-## Labels
+## Labels that matter
 
 Auto-merge keys off labels. `area/talos`, `needs-review`, and anything matching
 `ceph|cilium|flux|dragonfly` route to manual review. Do not add or remove labels to change how a PR

--- a/.github/mcp.json
+++ b/.github/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "radar": {
+      "type": "http",
+      "url": "http://localhost:49412/mcp",
+      "tools": ["*"]
+    }
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,11 @@ repos:
     rev: v8.18.3
     hooks:
       - id: gitleaks
+  - repo: local
+    hooks:
+      - id: sync-agents
+        name: Copilot agents match .claude/agents
+        entry: python3 scripts/sync_agents.py --check
+        language: system
+        files: ^\.(claude|github)/agents/.*\.md$
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,3 +210,48 @@ The Cloudflare skills come from the `cloudflare` plugin marketplace, enabled in
 
 These are configured per-project in `~/.claude.json`, not in the repo, because the Grafana service
 account token would otherwise be committed.
+
+## GitHub Copilot CLI
+
+Copilot CLI works in this repo too, sharing the same instructions and an equivalent set of agents.
+
+### What is shared automatically
+
+Copilot CLI discovers `AGENTS.md` and `CLAUDE.md` at the repository root on its own, and supports
+the same `@relative/path` include syntax, so `CLAUDE.md` → `@AGENTS.md` resolves there exactly as
+it does in Claude Code. **This file is the single source of truth for both tools** — no
+`.github/copilot-instructions.md` is needed, and adding one would only duplicate this.
+
+### Agents (`.github/agents/*.agent.md`)
+
+The same three agents as `.claude/agents/`, in Copilot's schema — `cluster-radar`, `grafana-logs`,
+and `ship`, with the same read-only and no-merge boundaries. Invoke one with:
+
+```bash
+copilot --agent cluster-radar -p "<question>"
+```
+
+Repository agents live in `.github/agents/`; user-level ones in `~/.copilot/agents/`, and a
+user-level agent of the same name wins. The two agent sets are deliberate duplicates: the schemas
+differ (Copilot namespaces MCP tools as `server/tool` and requires `description`), so **a change to
+an agent must be made in both places** or the tools drift apart.
+
+### MCP servers for Copilot
+
+Copilot CLI reads `~/.copilot/mcp-config.json` — it does **not** auto-load a repo-level
+`.github/mcp.json` (that path applies to other Copilot surfaces). `github-mcp-server` is built in,
+so only `radar` and `grafana` need configuring, and both live in the user config because of the
+Grafana token.
+
+`.github/mcp.json` is kept as the committed, secret-free definition of the radar server. Apply it
+explicitly with:
+
+```bash
+copilot --additional-mcp-config @.github/mcp.json
+```
+
+### Not shared
+
+Slash commands (`.claude/commands/`) and skills (`.claude/skills/`) are Claude Code only. Copilot
+CLI can load `.github/skills/`, but the skills are not duplicated there — their content is either
+already in this file or reachable by reading `.claude/skills/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,9 +232,23 @@ copilot --agent cluster-radar -p "<question>"
 ```
 
 Repository agents live in `.github/agents/`; user-level ones in `~/.copilot/agents/`, and a
-user-level agent of the same name wins. The two agent sets are deliberate duplicates: the schemas
-differ (Copilot namespaces MCP tools as `server/tool` and requires `description`), so **a change to
-an agent must be made in both places** or the tools drift apart.
+user-level agent of the same name wins.
+
+**`.github/agents/*.agent.md` is generated — do not edit it.** The two tools cannot share a file:
+Copilot namespaces MCP tools as `server/tool` where Claude Code uses `mcp__server__tool`, and the
+built-ins have different names (`Bash` vs `execute`), so a symlink would leave one tool with an
+unusable frontmatter. The bodies are identical, so `.claude/agents/` is the single source and the
+Copilot copies are generated from it:
+
+```bash
+python3 scripts/sync_agents.py           # regenerate after editing .claude/agents/
+python3 scripts/sync_agents.py --check   # what the pre-commit hook runs
+```
+
+The `sync-agents` pre-commit hook fails on any drift in either direction — an edit to a source
+that was not regenerated, or a hand-edit to a generated file. If an agent gains a tool with no
+Copilot equivalent, the script exits with the tool name rather than silently dropping it; add the
+mapping to `BUILTINS` in the script.
 
 ### MCP servers for Copilot
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,11 +234,33 @@ copilot --agent cluster-radar -p "<question>"
 Repository agents live in `.github/agents/`; user-level ones in `~/.copilot/agents/`, and a
 user-level agent of the same name wins.
 
-**`.github/agents/*.agent.md` is generated — do not edit it.** The two tools cannot share a file:
-Copilot namespaces MCP tools as `server/tool` where Claude Code uses `mcp__server__tool`, and the
-built-ins have different names (`Bash` vs `execute`), so a symlink would leave one tool with an
-unusable frontmatter. The bodies are identical, so `.claude/agents/` is the single source and the
-Copilot copies are generated from it:
+**`.github/agents/*.agent.md` is generated — do not edit it.**
+
+Copilot CLI *does* read `.claude/agents/*.md`, so symlinking the two directories — the usual advice
+for sharing AI config — looks like it works. It does not, and it fails silently. Verified against
+CLI v1.0.82:
+
+| Agent file | `tools:` entry | Result |
+| --- | --- | --- |
+| `.claude/agents/probe.md` | `mcp__github__get_me` | **silently dropped**; agent had built-ins only |
+| `.github/agents/probe.agent.md` | `github/get_me` | granted and invoked successfully |
+
+This is deliberate on GitHub's part — the docs state that "all unrecognized tool names are ignored,
+which allows product-specific tools to be specified in an agent profile without causing problems."
+That tolerance is what makes sharing *instruction* files across tools work so well, and it is
+exactly what makes sharing *agent* files dangerous: `cluster-radar` symlinked into Copilot would
+load cleanly, report no error, and have zero radar tools.
+
+Two facts worth keeping in mind:
+
+- `.github/agents/` **wins** over `.claude/agents/` on a name conflict, so the generated files are
+  the ones in effect. Deleting them does not fall back gracefully — it silently strips every MCP
+  tool from all three agents.
+- Copilot ignores `model:` with a warning (`specifies model "inherit" which is not available`), so
+  model selection cannot be shared either.
+
+The bodies are identical, so `.claude/agents/` is the single source and the Copilot copies are
+generated from it:
 
 ```bash
 python3 scripts/sync_agents.py           # regenerate after editing .claude/agents/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,15 +184,17 @@ automatically at session start.
 Delegate to these rather than doing cluster or log investigation inline: their output stays out of
 the main context window.
 
-Two behaviours worth knowing, both observed directly rather than inferred:
+Two behaviours worth knowing, both observed directly rather than inferred (Claude Code
+2.1.236, 2026-08-30 — re-check before relying on either if your build is much newer):
 
 - **Editing an agent file does not take effect until Claude Code restarts.** A `.claude/agents/*.md`
   edited mid-session keeps running with the definition loaded at startup — the agent will answer
   from its old instructions and give no indication they are stale. Restart before testing a change.
 - **Declared built-in tools can be silently dropped.** `cluster-radar` declares `Grep` and `Glob`
-  but a backgrounded run received neither — 25 tools instead of 27, with no error. It falls back to
-  `Bash` (`grep -rn …`) so nothing breaks, but do not assume a declared built-in is present.
-  MCP tools were unaffected.
+  but a backgrounded run received neither — 25 tools instead of 27, with no error. Seen once, in a
+  backgrounded subagent; whether foreground runs differ was not tested. It falls back to `Bash`
+  (`grep -rn …`) so nothing breaks, but do not assume a declared built-in is present. MCP tools
+  were unaffected.
 
 ### Skills (`.claude/skills/`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,16 @@ automatically at session start.
 Delegate to these rather than doing cluster or log investigation inline: their output stays out of
 the main context window.
 
+Two behaviours worth knowing, both observed directly rather than inferred:
+
+- **Editing an agent file does not take effect until Claude Code restarts.** A `.claude/agents/*.md`
+  edited mid-session keeps running with the definition loaded at startup — the agent will answer
+  from its old instructions and give no indication they are stale. Restart before testing a change.
+- **Declared built-in tools can be silently dropped.** `cluster-radar` declares `Grep` and `Glob`
+  but a backgrounded run received neither — 25 tools instead of 27, with no error. It falls back to
+  `Bash` (`grep -rn …`) so nothing breaks, but do not assume a declared built-in is present.
+  MCP tools were unaffected.
+
 ### Skills (`.claude/skills/`)
 
 - **gitbutler** — GitButler CLI (`but`) reference: commits, hunk selection, stacks, history edits.

--- a/scripts/sync_agents.py
+++ b/scripts/sync_agents.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
 """Generate .github/agents/*.agent.md (Copilot CLI) from .claude/agents/*.md.
 
-The two tools need the same agent definitions but cannot share a file: the tool
-namespaces are incompatible (``mcp__radar__diagnose`` vs ``radar/diagnose``), so
-a symlink would leave one of them with an unusable frontmatter. The bodies are
-identical, so the Copilot copy is generated instead of maintained by hand.
+Why generate rather than symlink the two directories together, which is the
+usual advice for sharing AI tool config:
+
+Copilot CLI does read .claude/agents/*.md, so a symlink appears to work. But the
+tool namespaces differ (``mcp__radar__diagnose`` vs ``radar/diagnose``), and
+Copilot *silently ignores* tool names it does not recognise -- documented
+behaviour, intended to let one agent file carry product-specific tools without
+breaking other products. For an agent whose whole value is its MCP tools, that
+tolerance is the problem: a symlinked cluster-radar loads cleanly, reports no
+error, and has no radar tools at all.
+
+The bodies are identical, so the Copilot copy is generated instead. Unknown tool
+names are a hard error here precisely because Copilot will not raise one.
 
 Usage:
     python3 scripts/sync_agents.py            # regenerate

--- a/scripts/sync_agents.py
+++ b/scripts/sync_agents.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Generate .github/agents/*.agent.md (Copilot CLI) from .claude/agents/*.md.
+
+The two tools need the same agent definitions but cannot share a file: the tool
+namespaces are incompatible (``mcp__radar__diagnose`` vs ``radar/diagnose``), so
+a symlink would leave one of them with an unusable frontmatter. The bodies are
+identical, so the Copilot copy is generated instead of maintained by hand.
+
+Usage:
+    python3 scripts/sync_agents.py            # regenerate
+    python3 scripts/sync_agents.py --check    # fail if out of date (pre-commit)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / ".claude" / "agents"
+DST = REPO / ".github" / "agents"
+
+# Claude built-in tool -> Copilot built-in tool. Unlisted names are a hard error
+# rather than a silent drop: a missing tool is an agent that fails at runtime.
+BUILTINS = {
+    "Read": "read",
+    "Grep": "search",
+    "Glob": "search",
+    "Bash": "execute",
+    "Edit": "edit",
+    "Write": "edit",
+}
+
+BANNER = (
+    "<!-- Generated from .claude/agents/{src} by scripts/sync_agents.py. "
+    "Edit that file, not this one. -->"
+)
+
+
+def split_frontmatter(text: str, path: Path) -> tuple[list[str], str]:
+    lines = text.split("\n")
+    if lines[0] != "---":
+        sys.exit(f"{path}: expected frontmatter to open with ---")
+    try:
+        end = lines.index("---", 1)
+    except ValueError:
+        sys.exit(f"{path}: unterminated frontmatter")
+    return lines[1:end], "\n".join(lines[end + 1 :])
+
+
+def convert_tools(value: str, path: Path) -> list[str]:
+    out: list[str] = []
+    for raw in value.split(","):
+        name = raw.strip()
+        if not name:
+            continue
+        if name.startswith("mcp__"):
+            parts = name.split("__", 2)
+            if len(parts) != 3:
+                sys.exit(f"{path}: cannot parse MCP tool {name!r}")
+            mapped = f"{parts[1]}/{parts[2]}"
+        elif name in BUILTINS:
+            mapped = BUILTINS[name]
+        else:
+            sys.exit(
+                f"{path}: no Copilot equivalent known for tool {name!r}. "
+                f"Add it to BUILTINS in {Path(__file__).name}."
+            )
+        if mapped not in out:  # Grep and Glob both map to search
+            out.append(mapped)
+    return out
+
+
+def render(path: Path) -> str:
+    fm, body = split_frontmatter(path.read_text(), path)
+    fields: dict[str, str] = {}
+    for line in fm:
+        if ":" not in line:
+            sys.exit(f"{path}: unexpected frontmatter line {line!r}")
+        key, _, value = line.partition(":")
+        fields[key.strip()] = value.strip()
+
+    for required in ("name", "description", "tools"):
+        if required not in fields:
+            sys.exit(f"{path}: frontmatter is missing {required!r}")
+
+    tools = json.dumps(convert_tools(fields["tools"], path))
+    # 'model' is intentionally dropped: Copilot CLI selects the model itself.
+    head = "\n".join(
+        [
+            "---",
+            f"name: {fields['name']}",
+            f"description: {fields['description']}",
+            f"tools: {tools}",
+            "---",
+            "",
+            BANNER.format(src=path.name),
+        ]
+    )
+    return f"{head}\n{body}"
+
+
+def main() -> int:
+    check = "--check" in sys.argv[1:]
+    sources = sorted(SRC.glob("*.md"))
+    if not sources:
+        sys.exit(f"no agents found in {SRC}")
+
+    stale: list[str] = []
+    for src in sources:
+        dst = DST / f"{src.stem}.agent.md"
+        want = render(src)
+        have = dst.read_text() if dst.exists() else None
+        if want == have:
+            continue
+        if check:
+            stale.append(f"  {dst.relative_to(REPO)} (from {src.relative_to(REPO)})")
+        else:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_text(want)
+            print(f"wrote {dst.relative_to(REPO)}")
+
+    for dst in sorted(DST.glob("*.agent.md")):
+        if not (SRC / f"{dst.name.removesuffix('.agent.md')}.md").exists():
+            stale.append(f"  {dst.relative_to(REPO)} has no source in .claude/agents/")
+
+    if stale:
+        print("Copilot agents are out of sync with .claude/agents/:", file=sys.stderr)
+        print("\n".join(stale), file=sys.stderr)
+        print("\nRun: python3 scripts/sync_agents.py", file=sys.stderr)
+        return 1
+    if check:
+        print(f"{len(sources)} agents in sync")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Makes GitHub Copilot CLI work on this repo with the same setup as Claude Code, with the Copilot agent files **generated** from `.claude/agents/` rather than maintained by hand.

- **NEW** `.github/agents/cluster-radar.agent.md`, `grafana-logs.agent.md`, `ship.agent.md` — the three agents from `.claude/agents/`, in Copilot's schema. Generated; do not edit.
- **NEW** `.github/mcp.json` — the radar MCP server only (an `http` URL, no credentials).
- **NEW** `scripts/sync_agents.py` — renders the Copilot agent files from `.claude/agents/*.md`.
- **MODIFIED** `.pre-commit-config.yaml` — a `sync-agents` hook running `sync_agents.py --check`.
- **MODIFIED** `AGENTS.md` — appends a `## GitHub Copilot CLI` section.
- **MODIFIED** `.claude/agents/{cluster-radar,ship}.md` — folds in improvements that had ended up only on the Copilot side.

**Instructions were already shared for free.** Copilot CLI auto-discovers `AGENTS.md` and `CLAUDE.md` at the repo root and supports the same `@relative/path` include syntax, so `CLAUDE.md` → `@AGENTS.md` already resolved there with zero changes. No `.github/copilot-instructions.md` was added on purpose — it would only duplicate `AGENTS.md`.

**`.github/mcp.json` is not auto-loaded by the CLI.** Verified empirically: with `.github/mcp.json` alone the radar server did not appear; it appeared only when passed via `--additional-mcp-config @.github/mcp.json`. Copilot CLI reads `~/.copilot/mcp-config.json`. It is committed anyway as the secret-free reference definition, and `AGENTS.md` documents the explicit flag.

## Why the agent files are generated, not symlinked

The first commit maintained the two agent sets as hand-kept duplicates. **That had already drifted before review:** the zsh shell note existed only in `.github/agents/`, and `ship.agent.md` granted an `edit` tool that `.claude/agents/ship.md` deliberately withholds.

Symlinking the two directories is the widely recommended fix — it is the standard advice for sharing AI tool config, and at least one popular write-up recommends exactly `.claude/agents/` → `.github/agents/` (while admitting the author never tested whether the agents actually function afterwards). **It does not work here, and it fails silently.**

Copilot CLI *does* read `.claude/agents/*.md`, which is what makes this a trap. A/B probe against CLI v1.0.82 — same MCP server, same tool, only the file differs:

| Agent file | `tools:` entry | Result |
| --- | --- | --- |
| `.claude/agents/probe.md` | `mcp__github__get_me` | **silently dropped** — agent had built-ins only |
| `.github/agents/probe.agent.md` | `github/get_me` | granted as `github-mcp-server-get_me`, invoked, returned `axeII` |

GitHub documents the behaviour: *"All unrecognized tool names are ignored, which allows product-specific tools to be specified in an agent profile without causing problems."* That tolerance is precisely what makes sharing **instruction** files across tools work so well, and what makes sharing **agent** files dangerous. A symlinked `cluster-radar` would load cleanly, raise no error, and have zero radar tools.

Two further findings, both load-bearing and non-obvious, now recorded in `AGENTS.md`:

- **`.github/agents/` wins over `.claude/agents/`** on a name conflict. So the generated files are the ones in effect — and deleting them does not fall back gracefully, it silently strips every MCP tool from all three agents.
- **Copilot ignores `model:`** with a warning (`specifies model "inherit" which is not available`), so model selection cannot be shared either.

So `.claude/agents/` is the single source and the Copilot copies are generated:

```bash
python3 scripts/sync_agents.py           # regenerate
python3 scripts/sync_agents.py --check   # what the pre-commit hook runs
```

Unknown tool names are a **hard error** in the script specifically because Copilot will not raise one. Both drift directions were tested by injecting drift and confirming a non-zero exit: a source edit that was not regenerated, and a hand-edit to a generated file.

Generation caught the `edit` over-grant on its first run. To be precise about that one: `ship` still has shell access and can therefore write files, so it is a consistency fix, not a security boundary. `ship`'s real boundary is the absent `merge_pull_request`.

## Risk

**Low — tooling config only.** No Kubernetes manifests, no Talos config, no cluster state. Nothing under `kubernetes/` or `talos/` changed, so Flux has nothing to reconcile. Blast radius is local agent tooling on developer machines.

Agent boundaries, verified against the committed files:

- `cluster-radar` — 23 read-only radar tools; all 7 mutating ones (`apply_resource`, `patch_resource`, `manage_workload`, `manage_node`, `manage_gitops`, `manage_cronjob`, `manage_rollout`) excluded.
- `grafana-logs` — 23 read-only Grafana tools (query/list/get/search only).
- `ship` — `merge_pull_request` absent; it can open and update PRs but cannot merge.

**No credentials committed.** `.github/mcp.json` holds only the radar `http://localhost:49412/mcp` URL. The Grafana server needs a service-account token, so it lives outside the repo in `~/.copilot/mcp-config.json` (mode 600, uncommitted). A repo-level `grafana` entry was deliberately avoided for a second reason: project config takes precedence on name conflict, so it would have overridden the working user-level one.

One scope limit to flag: **no CI job runs pre-commit in this repo**, so the `sync-agents` hook guards the local commit path only. An edit made through the GitHub web UI would not be caught. Adding a CI check is a deliberate follow-up decision, not an oversight.

## Validation

Nothing under `kubernetes/` or `talos/` changed, so manifest validation is not applicable. Explicit about what ran versus what was skipped:

- `pre-commit run --files` against every changed and new file — **passed** (including gitleaks, sops forbid-secrets, yamllint, and the new `sync-agents`). Run with explicit paths because `--all-files` silently skips untracked files.
- `sync-agents` drift test — **passed in both directions**, verified by deliberately injecting drift and confirming exit 1, then exit 0 after restore.
- markdownlint against `.github/linters/.markdownlint.yaml` — **no new errors**. 20 MD060 findings exist, all pre-existing in the auto-merge and WAF tables; count measured before and after against a stashed tree, identical. The one table added by this PR uses a spaced separator so it is MD060-clean.
- `scripts/find_mistakes.py` — 2 warnings, both pre-existing and unrelated (`affine` unregistered, `rook-ceph` missing common component).
- `just configure` — **skipped**; pre-existing broken on this machine (`.venv/bin/makejinja` missing), fails identically on a clean tree.
- `just validate` / `just flate-test` — **not run** (no manifest changes).
- Functionally tested against the real CLI (v1.0.82): `copilot --agent grafana-logs` on the **generated** file returned its own name and correctly recited the hardcoded Loki datasource UID `P8E80F9AEF21F6940`, proving the body is read. `copilot --agent ship` loads with the tightened grant. The `cluster-radar` and `grafana-logs` generated frontmatter is byte-identical to the hand-written versions verified in the first commit — only `ship` changed.

All probe agents created during testing were removed; the working tree is clean.


---

## Follow-up commit: `docs(agents): correct shell notes with a per-tool comparison`

Live-testing the agents against both CLIs turned up three corrections. Documentation only.

**The shell notes were wrong.** `.claude/agents/{cluster-radar,ship}.md` asserted the shell is zsh.
Direct probes show the two tools disagree with each other, and neither runs the `fish` that Claude
Code's environment block advertises:

| Tool | Shell it actually runs |
| --- | --- |
| Claude Code `Bash` | zsh 5.9 (`ps` reports `/bin/zsh`) |
| Copilot CLI shell | bash 3.2.57 (`ps` reports `/bin/bash`) |

Since one source file now feeds both tools, the note became that table plus rules that hold in
either shell: quote every expansion, quote any argument containing `[`, `*`, or `?` (an unmatched
glob is fatal in zsh but a literal in bash), and avoid bash 4+ syntax because macOS ships bash 3.2.

**Two more verified Claude Code behaviours, recorded in `AGENTS.md`.** Both observed, not inferred:

- Editing a `.claude/agents/*.md` does not take effect until Claude Code restarts. A live agent kept
  answering from its pre-edit instructions and gave no indication they were stale.
- Declared built-in tools can be silently dropped. `cluster-radar` declares `Grep` and `Glob`, but a
  backgrounded run received neither — 25 tools instead of 27, with no error. MCP tools were
  unaffected, and the agent falls back to `Bash`, so nothing breaks; the point is that a declared
  built-in cannot be assumed present.

**MD060 fix** — `grafana-logs` carried a pre-existing unspaced table separator; switched to the
spaced style.

The three `.github/agents/*.agent.md` changes in this commit are regenerated output from
`scripts/sync_agents.py`, not hand edits.

### Validation for this commit

- `pre-commit run --all-files` — **passed** (11 hooks, including `sync-agents`, gitleaks, and sops
  forbid-secrets). It modified nothing, so there was no reformatting to fold back in.
- `python3 scripts/sync_agents.py --check` — **passed**, "3 agents in sync".
- markdownlint against `.github/linters/.markdownlint.yaml`, re-run over all seven changed files —
  **no new errors**. All six agent files are clean; the 20 MD060 findings are entirely in
  `AGENTS.md` lines 118 and 145, the auto-merge and WAF tables, which this commit does not touch.
  Same baseline as before.
- `just configure`, `just validate`, `just flate-test`, `scripts/find_mistakes.py` — **not run, and
  not applicable**. Nothing under `kubernetes/` or `talos/` changed, so there is nothing for Flux to
  render or reconcile. `just configure` also remains pre-existing broken on this machine
  (`.venv/bin/makejinja` missing) and fails identically on a clean tree.
- CI on the pushed head: `yaml`, `checks`, `Flate - Filter`, `Labeler`, and `Konflate` all green;
  `Flate - Test` skipped by the path filter, as expected for a no-manifest change.
