### PR TITLE
fix(rook-ceph): disable rook mgr module and rotate rbd-mirror-peer key

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -51,6 +51,14 @@ spec:
           daemon:
             keyRotationPolicy: KeyGeneration
             keyGeneration: 2
+          # No CephRBDMirror is configured, so there are no peer clusters whose
+          # connection this rotation could break. Takes the insecure entity count
+          # from 5 to 4. The four client.csi-* keys cannot follow until every node
+          # runs Linux 7.0+ (see issue #3841); the chart default keeps them on aes.
+          rbdMirrorPeer:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
+            keyType: aes256k
       cephConfig:
         global:
           bdev_enable_discard: "true"
@@ -86,9 +94,13 @@ spec:
         modules:
           - name: pg_autoscaler
             enabled: true
-          # Enable this if you want to use the Rook dashboard some features
+          # Upstream disables the rook mgr module on Ceph v20.2.2-v20.2.4 regardless
+          # of this value: v20.2.2 leaks memory, v20.2.3/v20.2.4 crash the mgr. Asking
+          # for it was a no-op that only made the manifest disagree with the cluster.
+          # The only cost of leaving it off is a few orchestrator pages in the Ceph
+          # dashboard. https://rook.io/docs/rook/latest-release/Upgrade/ceph-upgrade/
           - name: rook
-            enabled: true
+            enabled: false
       crashCollector:
         disable: false
       dashboard:


### PR DESCRIPTION
Two follow-ups to #3841, both in `kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml`. Surfaced while reviewing #3858 (Rook v1.20.7).

## 1. `mgr.modules[rook].enabled: true` → `false`

Rook **force-disables** the rook mgr module on Ceph v20.2.2–v20.2.4 regardless of this setting — v20.2.2 leaks memory, v20.2.3/v20.2.4 crash the mgr ([`rookModuleDisabledForCephVersion()`](https://github.com/rook/rook/blob/v1.20.7/pkg/operator/ceph/cluster/mgr/mgr.go#L490)). The spec loop then hits an explicit `if module.Name == rookModuleName && c.rookModuleDisabledForCephVersion() { continue }` guard, so our `enabled: true` has been silently dropped this whole time.

That module is the source of the 2965 archived `node_proxy_fullreport` → `NotImplementedError` mgr crash entries cleared during the 2026-08-30 incident. Rook v1.20.7 also adds ["Disable the rook mgr module"](https://rook.io/docs/rook/latest-release/Upgrade/ceph-upgrade/) as explicit pre-Tentacle upgrade guidance.

**Effect:** none on the running cluster — the module is already off. This makes the manifest state the truth instead of a request that is ignored. Cost of leaving it off is a few orchestrator pages in the Ceph dashboard.

## 2. Rotate `client.rbd-mirror-peer` to `aes256k`

The kernel-independent follow-up already scoped in #3841. No `CephRBDMirror` is configured, so there are no peer clusters whose connection this could break. Takes the insecure entity count **5 → 4**.

```yaml
rbdMirrorPeer:
  keyRotationPolicy: KeyGeneration
  keyGeneration: 2
  keyType: aes256k
```

`status.cephx.rbdMirrorPeer` is currently `{}`, so `ShouldRotateCephxKeys()` sees `cfg.KeyGeneration (2) > status.KeyGeneration (0)` and rotates once. Daemon keys already sit at generation 2 / `aes256k`; this brings the mirror peer in line.

## What this does *not* change

The four `client.csi-*` keys stay on `aes`. They still require Linux kernel 7.0+ (7.2 under FIPS) and nodes run `6.18.38-talos`. The three health mutes stay in place and #3841 stays open.

## Risks / cautions

- **This rotates a live cephx key.** It is the one entity in the flagged set with no consumer, so the blast radius is nil, but it is a real `ceph auth` mutation rather than a config no-op. Verify with `ceph auth ls | grep rbd-mirror-peer` afterwards.
- Independent of #3858 — merges cleanly in either order.
- No daemon restarts expected from either change.

## Validation

- `flate test all --path kubernetes/flux` → 169 passed
- `python3 scripts/find_mistakes.py` → 2 warnings, both pre-existing and unrelated (verified by re-running against the unmodified file)
- `pre-commit run --all-files` → all passed
- Rendered CephCluster confirmed to carry `mgr.modules[rook].enabled: false`, the new `rbdMirrorPeer` block, and an unchanged `csi.keyType: aes`

`just configure` could not run locally — its first step is `.venv/bin/makejinja`, but there is no `templates/` directory and no makejinja in the venv (pre-existing, unrelated). `yayamlls` is not installed locally either; CI covers it.

## Post-merge verification

```bash
kubectl -n rook-ceph get cephcluster rook-ceph -o jsonpath='{.status.cephx}{"\n"}'
# expect rbdMirrorPeer: generation 2, keyType aes256k

kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph health detail
# expect: HEALTH_OK (muted: AUTH_INSECURE_CLIENT_KEY_TYPE AUTH_INSECURE_KEYS_ALLOWED AUTH_INSECURE_KEYS_CREATABLE)
# and "4 auth client entities with insecure key types" (down from 5) under the muted check
```

https://claude.ai/code/session_017ECqukE9Ci8WJ4WXWnBByU