### PR TITLE
fix(tuppr): give ceph noout hooks a writable /tmp

### DIFF
--- a/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
@@ -52,10 +52,17 @@ spec:
         volumeMounts:
           - name: ceph-config
             mountPath: /etc/ceph
+          # tuppr builds hook pods with readOnlyRootFilesystem: true, so the
+          # redirects above need a writable /tmp. fsGroup 65532 on the hook pod
+          # makes this emptyDir writable by the hook's uid.
+          - name: tmp
+            mountPath: /tmp
         volumes:
           - name: ceph-config
             secret:
               secretName: rook-ceph-config
+          - name: tmp
+            emptyDir: {}
     post:
       - name: ceph-unset-noout
         image: docker.io/rook/ceph:v1.20.7
@@ -78,7 +85,14 @@ spec:
         volumeMounts:
           - name: ceph-config
             mountPath: /etc/ceph
+          # tuppr builds hook pods with readOnlyRootFilesystem: true, so the
+          # redirects above need a writable /tmp. fsGroup 65532 on the hook pod
+          # makes this emptyDir writable by the hook's uid.
+          - name: tmp
+            mountPath: /tmp
         volumes:
           - name: ceph-config
             secret:
               secretName: rook-ceph-config
+          - name: tmp
+            emptyDir: {}


### PR DESCRIPTION
## What

Mounts an `emptyDir` at `/tmp` in both the `ceph-set-noout` pre-hook and the `ceph-unset-noout` post-hook of `TalosUpgrade/cluster`.

## Why

The Talos v1.13.9 upgrade in the **2026-09-06 02:00 Europe/Paris** maintenance window did not run. `TalosUpgrade/cluster` went `phase: Failed` one minute in:

> Pre-upgrade hook failed; upgrade did not run

Both hooks died on their very first line:

```
sh: line 1: /tmp/ceph.conf: Read-only file system
```

tuppr builds hook pods with `ReadOnlyRootFilesystem: true` (`internal/controller/jobs/jobs.go`, `BuildHookPodSpec`). Our hooks write `/tmp/ceph.conf` and `/tmp/keyring` before invoking `ceph`, and nothing writable was mounted there. `ceph osd set noout` never executed.

### Why this surfaced now

`ReadOnlyRootFilesystem: true` has been in tuppr's hook pod spec since hooks were introduced ([`13a4364a`](https://github.com/home-operations/tuppr/commit/13a4364a), 2026-05-01) — verified by reading `jobs.go` at that revision. **These hooks have never once worked.**

What changed is tuppr **0.5.2** (2026-08-27), [`7de04398`](https://github.com/home-operations/tuppr/commit/7de043980a8e65f991d7933ca1a422bf9f17a2f4) — *"judge Job outcome by the JobFailed condition, not Failed vs backoffLimit"*. Before that, tuppr did not notice the hook had failed.

So the v1.13.6 upgrade that reported `Completed` on 2026-07-19 ran with `noout` never set. It was fine in practice: `mon_osd_down_out_interval` is `600`s and a Talos reboot finishes well inside ten minutes, so no rebalance was ever triggered. 0.5.2 turned a silent no-op into a hard stop — the correct trade, since tuppr now refuses to upgrade rather than upgrading without the safety flag it was asked to set.

## Approach

Kept the file-based config rather than switching to the env-var form in [upstream's hook example](https://tuppr.home-operations.com/talos-upgrades/). That example writes no files, which is how it sidesteps the read-only rootfs — but it would mean passing the admin key as a CLI argument, which is worse hygiene than a file on a tmpfs. The hook pod already sets `fsGroup: 65532`, so an `emptyDir` is writable by the hook's uid with no further change.

## Validation

| Step | Result |
|---|---|
| `kubectl apply --dry-run=server` | **`configured`** — the live tuppr admission webhook accepts the `emptyDir` volumes |
| `just flate-test` | 169 passed (1 pre-existing warning, `network/external-dns-cloudflare`) |
| `python3 scripts/find_mistakes.py` | 2 pre-existing warnings, both unrelated (`affine` registration, `rook-ceph` common component) |
| `pre-commit run --all-files` | all passed |
| `just configure` / `just validate` | **not run** — no `makejinja` in `.venv` and `yayamlls` not installed locally. Pre-existing environment gap, unrelated to this change; CI covers yayamlls |

## Cluster state

Unaffected by the failed run and healthy at time of writing:

- Ceph `HEALTH_OK`, 81/81 PGs `active+clean`, 3 OSDs up/in
- `noout` is **not** stuck set — the pre-hook died before reaching the `ceph` command
- All 15 Rook daemons on `v1.20.7` / ceph `20.2.4-0`
- Every Flux Kustomization and HelmRelease Ready

Nodes remain on **Talos v1.13.6**; target is v1.13.9. Next maintenance window is **Sunday 2026-09-13 02:00 Europe/Paris**.

## Related: stranded taints (#3866)

The failed run left `tuppr.home-operations.com/outdated:PreferNoSchedule` on all three nodes for the second consecutive window. **I cleared them manually before opening this PR.**

This is a *distinct* stranding path from the one #3866 documents. Traced in the source:

- `findNextNodes` applies the taint at [`upgrade.go:609`](https://github.com/home-operations/tuppr/blob/main/internal/controller/talosupgrade/upgrade.go) — **before** the image pre-pull and before pre-hooks run, so it lands the moment the window opens regardless of whether the upgrade proceeds.
- Once the phase is terminal `Failed`, the reconcile returns early at `upgrade.go:66` and never calls `findNextNodes` again, so nothing removes them.

#3866 covers the `FailedNodes` path. This run had `failedNodes: []` **and** `completedNodes: []` — a terminal `Failed` phase strands the taint just as hard. Worth folding into that issue when the gate decision is made.

## Risk

Low. Additive only — one `emptyDir` volume and mount per hook, no change to the hook commands, the upgrade policy, health checks, or the maintenance window. Worst case is that the hooks keep failing exactly as they do today; the upgrade already refuses to run in that state, so there is no path here that makes the cluster less safe.

The first real exercise is the 2026-09-13 window.
