### PR TITLE
tmp(tuppr): drop maintenance window to run v1.13.9 attended

### DIFF
--- a/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
@@ -15,11 +15,17 @@ spec:
     timeout: 30m
     stage: false
   parallelism: 1
-  maintenance:
-    windows:
-      - start: "0 2 * * 0"
-        duration: "4h"
-        timezone: "Europe/Paris"
+  # TEMPORARY - REVERT AFTER THE v1.13.9 RUN COMPLETES.
+  # tuppr treats an absent maintenance block as "always allowed", so dropping
+  # the window lets the upgrade start as soon as Flux applies this, attended,
+  # instead of waiting for Sunday 02:00. The 2026-09-06 window was consumed by
+  # the failed pre-hook (see #3870) and the nodes are still on v1.13.6.
+  # Restore the block below as soon as all three report v1.13.9.
+  # maintenance:
+  #   windows:
+  #     - start: "0 2 * * 0"
+  #       duration: "4h"
+  #       timezone: "Europe/Paris"
   healthChecks:
     - apiVersion: v1
       kind: Node


### PR DESCRIPTION
## What

Comments out the `maintenance:` block on `TalosUpgrade/cluster` so the pending **v1.13.9** run starts as soon as Flux applies it, rather than waiting for the next window.

**This is deliberately temporary. Revert it as soon as all three nodes report v1.13.9.**

## Why

The 2026-09-06 02:00 Europe/Paris window was consumed by the pre-hook failure that #3870 fixes — `phase: Failed`, `completedNodes: []`, no node touched. All three nodes are still on **Talos v1.13.6**; the target is v1.13.9. Without this, the next attempt is Sunday **2026-09-13 02:00**, unattended.

Running it now means someone is awake and watching the first exercise of the repaired hooks.

## How it works

`maintenance.CheckWindow` (`internal/controller/maintenance/window.go:33`) returns `Allowed: true` immediately when the spec is nil or has no windows:

```go
if spec == nil || len(spec.Windows) == 0 {
    return &WindowResult{Allowed: true}, nil
}
```

Merging #3870 also clears the terminal `Failed` state on its own — `handleGenerationChange` resets the phase to `Pending` and zeroes `preHookFailed`, `completedNodes`, `failedNodes`, and both hook indices on any spec change. So no `tuppr.home-operations.com/reset` annotation is needed.

## Ordering

**Stacked on #3870 — merge that first.** If this landed alone, tuppr would immediately start a run against the still-broken hooks and fail the same way. GitHub will retarget this to `main` once #3870 merges.

## Scope

Only the maintenance block. Untouched: target version, `parallelism: 1`, `placement: hard`, both health checks (Node Ready, CephCluster `HEALTH_OK`), and both noout hooks.

## Risk

The real risk is **forgetting to revert**. With no window, any future outdated node upgrades immediately at whatever hour it is noticed — no Sunday-morning containment. That is the entire reason this is a separate PR from #3870 rather than folded into it: it is meant to be reverted within the hour, and a standalone commit makes that a one-click `Revert`.

The upgrade itself carries normal risk. `parallelism: 1` with Ceph pools at `replicated: size 2` across 3 hosts means one host down still leaves a copy, and `noout` (now that it actually gets set) suppresses rebalancing during the reboot.

## Validation

| Step | Result |
|---|---|
| `kubectl apply --dry-run=server` | `configured` — live tuppr webhook accepts it |
| `just flate-test` | 169 passed (1 pre-existing unrelated warning) |
| `pre-commit run --all-files` | all passed |
| YAML parse | `maintenance` key absent; hooks, health checks, target, parallelism all intact |