### PR TITLE
fix(tuppr): decrypt ceph-secrets.sops.yaml

### DIFF
--- a/kubernetes/apps/system-upgrade/ks.yaml
+++ b/kubernetes/apps/system-upgrade/ks.yaml
@@ -8,6 +8,14 @@ spec:
   dependsOn:
     - name: external-secrets-stores
       namespace: kube-system
+  # ./app contains ceph-secrets.sops.yaml. Without this block Flux applies the
+  # file verbatim and the Secret ends up holding raw ENC[AES256_GCM,...]
+  # ciphertext, which is what the tuppr ceph hooks were mounting as their
+  # keyring and mon_host.
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
   path: ./kubernetes/apps/system-upgrade/app
   prune: true
   sourceRef:


### PR DESCRIPTION
## What

Adds the missing `decryption` block to the `tuppr` Kustomization in `kubernetes/apps/system-upgrade/ks.yaml`.

## Why

With #3870 merged, the ceph hooks got past the read-only `/tmp` error and finally wrote their config files — which revealed a **second, independent bug** sitting underneath:

```
auth: error parsing file /tmp/keyring: error setting modifier for [client.admin]
  type=key val=ENC[AES256_GCM,data:...,type:str]: Malformed input [buffer:3]
unable to parse addrs in 'ENC[AES256_GCM,data:...,type:str]'
monclient: get_monmap_and_config cannot identify monitors to contact
[errno 22] RADOS invalid argument (error connecting to the cluster)
```

The hook wrote its keyring and `ceph.conf` correctly. The **contents** were raw SOPS ciphertext.

`kubernetes/apps/system-upgrade/app/kustomization.yaml` includes `ceph-secrets.sops.yaml`, but the `tuppr` Kustomization had no `decryption` block — so kustomize-controller applied the file verbatim, ENC strings and all. Confirmed against live state:

| Namespace | Secret | Value starts with |
|---|---|---|
| `system-upgrade` | `rook-ceph-mon` / `ceph-secret` | `ENC[AES256_GCM...` |
| `system-upgrade` | `rook-ceph-config` / `mon_host` | `ENC[AES256_GCM...` |
| `rook-ceph` | `rook-ceph-mon` / `ceph-secret` | *(real key)* |
| `rook-ceph` | `rook-ceph-config` / `mon_host` | `[v2:192.168.69...` |

Both Secrets are 49 days old, matching `204f23517 fix(tuppr): add ExternalSecrets for rook-ceph secrets, re-enable ceph hooks`. They have never contained anything usable.

## Scope

I audited every `.sops.yaml` in the repo against its owning `ks.yaml`. **This was the only one missing the block** — `cert-manager` and `external-secrets/stores/onepassword` both have it. Isolated bug, not systemic.

`sops-age` is already present in the `system-upgrade` namespace, so the `secretRef` resolves without any further change.

## Why nobody noticed

Same reason as #3870: tuppr ignored hook failures entirely until 0.5.2 (2026-08-27) started judging jobs by the `JobFailed` condition. Two independent breakages were stacked on top of each other, both silent. #3870 fixed the outer one; this is the inner one.

## Validation

| Step | Result |
|---|---|
| `just flate-test` | 169 passed (1 pre-existing unrelated warning) |
| `python3 scripts/find_mistakes.py` | 2 pre-existing warnings, both unrelated |
| `pre-commit run --all-files` | all passed |

## After merge

Decrypting the Secret does not change the `TalosUpgrade` spec, so there is no generation bump and tuppr stays in its terminal `Failed` state. It needs the `tuppr.home-operations.com/reset` annotation to retry — I'll apply that once the Secrets show plaintext, then watch the run.

**#3871 is still in effect** (maintenance window commented out), so the retry starts immediately rather than waiting for Sunday. That still needs reverting once v1.13.9 lands on all three nodes.

## Risk

Low as a change — four lines, one Kustomization, no workload touched.

Worth stating plainly though: this makes the Ceph **admin** key readable as a normal Secret in the `system-upgrade` namespace for the first time. That was the existing design's intent (the file was committed for exactly this purpose), but it has never actually been true until now. If you'd rather the hooks used a scoped-down Ceph user instead of `client.admin`, that's a reasonable follow-up — it's out of scope here, where the goal is getting the upgrade unblocked today.
