### PR TITLE
fix(tuppr): refresh stale ceph credentials in ceph-secrets.sops.yaml

### DIFF
--- a/kubernetes/apps/system-upgrade/app/ceph-secrets.sops.yaml
+++ b/kubernetes/apps/system-upgrade/app/ceph-secrets.sops.yaml
@@ -4,26 +4,26 @@ metadata:
   name: rook-ceph-mon
 type: kubernetes.io/rook
 stringData:
-  ceph-secret: ENC[AES256_GCM,data:oCQ3uHC6N9fqAMyy5jOCn0Pzvb4S/mjHUNb1zXLtIA0A8N8lBQQCHg==,iv:y+eJqvO40ieI0NQo+yPNEuRkzqi7XsfRa6lPgJZmfCo=,tag:YfjrCgdgbwFO47MwlYb1SA==,type:str]
-  ceph-username: ENC[AES256_GCM,data:1KzbateLQ+i37qy4,iv:xjTW+XxIf/KMUxNGHai+Wicm9anKSjGkErWHp8ibaYY=,tag:fvBj5zfM3733+CU48vnidw==,type:str]
-  fsid: ENC[AES256_GCM,data:8xgXZi+YH2svlH0jSrMkCIkchGNzSWZkgnQasgMBB21EAz7g,iv:F3uwDlj+1q6KUKYVhTPWi0PHcR4Io2qXGFCy01o2gUE=,tag:GVXN62g9xPqf7LxnsJS7bw==,type:str]
-  mon-secret: ENC[AES256_GCM,data:2SbxOK73xBsjBzEBNy2Y/bHSykJU7uI+ywktXLFdcRt8vy4oov+AmA==,iv:qQNYswGt9oCaNxvHUzZCN8V2Ly3B2mAGA4tFSY9c7lA=,tag:Ba0dGPZxWn1SElXUt10htQ==,type:str]
+  ceph-secret: ENC[AES256_GCM,data:2oFZllTp0cT39a1QqKVeyz0PYlCRnLDcFGOTqE6GKRSnUOVgBB84Dz6KtuuLT9cmIjCRk2fIsDt7n/Oj,iv:uIuQNTzHJh8pNU273gG8evEBqCCKoYMLBebpE811vhY=,tag:0+SHEDyDTiRXzLv/b/EU6Q==,type:str]
+  ceph-username: ENC[AES256_GCM,data:bjwzgPFTRKEyG54w,iv:y7xdkadn88Q8a4LXxkzZmu3t0aLpE58tCziaQ5pFeA0=,tag:HYgPS7qP3DZLwmpVgKtl/g==,type:str]
+  fsid: ENC[AES256_GCM,data:qT7zGiJ9M+UXss0+if577HFfIL74VuVMSiUeDEE9gWrGx6DO,iv:ZxCYVkE/SSqsYyEDk9jRsqDdTa0NiS0PDAF8ENMJ03E=,tag:H56uW+jLSnCI7yJuN7nYKw==,type:str]
+  mon-secret: ENC[AES256_GCM,data:a1pZrTV5TQQir3ai0YI2IUL9qe3MOMA4dTWBWfp47E6H8hNqfoWk536leelWnriX71bquFX5SQBn7WX2,iv:td1DMVTJZzWyC8t2MQpWK43YqBhdpDKDqdNVF4P5Zgg=,tag:HqUU1O8zuGVdzkjoxgKO1Q==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMV3BYSFhTNXVXMHF6MzF1
-        Y3FEdGltaTUvc0lhUnFKUHhMQzJtcC9JQlNnClYyajl1UCtVOUxlbGFaVC94N3Bh
-        dWU3Skh5a1ZDTnB0OTd6dG9FNjFtbW8KLS0tIDZmNUpNZm5LSHRxZUlDSDNoSXhZ
-        KzA4bmJjTXArTkZvMVFoS08xSzFoTWMKOze2M2iTjTSpkBLOevA6D9cX33m7oWZv
-        HBV71Lr8yVX6CM4Kq0lBJaaGtlA6cSntIDo3EwAN3793ytbv9+JeKA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBib0owdnZSVk5kU1pwNmFy
+        VGVkWlBsaisrRTJHalJ6WnFkVW4vZGRGRVVvCmVrUytPdXVwYXRBT0dMN3BPZzlx
+        ejgzOTV2RmxwLzVZcExNTXRjeElETUEKLS0tIG8zMGlIbXNqWjd1SjB2d0JKUFlY
+        OEY3SHlaOHhIT0s5VEZBK0E2ZmZJK1UKrQR//EpzIoVuCzculQ/exsoFg9SZd47X
+        c4N2T2Isy5vZb3QKXS62w2zWbzmrLMw1Yszhx1RGeCJT2Aqe3Fpfww==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1ryhy9dduzk5hyn33lnm7swtg72r7luklfv397s3wmhqav099w95s3cu3rh
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-07-18T22:18:26Z"
-  mac: ENC[AES256_GCM,data:md5I/FEMQ+qsZnjqBNbD8Au+KmxTlFs4G/Sb7+OY+UsOomJ/OELtsRjKkZLUBEQftNj3vriih5BDaD+ZQKx3NzbognTLs6mkNMg64xCMjf0NLvYziMlZ8jArSLlqSAakLO+z+9lKhOQ1K0ONtX26UC2edjhDcldxSHEP0fXKb18=,iv:ZrFuQQht/n1XPgUBocN84tOcBmtEElcXZk2io5DN/+0=,tag:hnBkPrB1UpNWfmdZxAFnPQ==,type:str]
+  lastmodified: "2026-09-06T14:14:00Z"
+  mac: ENC[AES256_GCM,data:BhhAK1oVFWnGlFukaqG3dRYegtWiQa8cYYdu8ha4WGp39RG0wm1S2mjGdMFs9u5LICrl2N36u6bvmEMnZBRyC6JBAFFZiXSyaEIQi+FXaDMze/tt/yuRbP0CyDKvpIqSdL5yo0AGkxwM3DTqOQNva2HBYK4JnP6IqG7MAyGUm6U=,iv:mjY2dU93uMrfrv4qhe+UtXtPsZ1SixjhEuv0v6h+qOA=,tag:zxLDCc+IXxt5ajO9wEX8Nw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.2
+  version: 3.13.3
 ---
 apiVersion: v1
 kind: Secret
@@ -31,21 +31,21 @@ metadata:
   name: rook-ceph-config
 type: kubernetes.io/rook
 stringData:
-  mon_host: ENC[AES256_GCM,data:e2t/e+Rsc8OyWJn0XEyBTawlMkdk4Wi594Jtxh+gUnQVUR865K/azd6ruf4Mn468biKhuTVaNEMQlHaiUyQBSFJ8oCKV2ZMkVFo=,iv:pg/4/ZTVn2uFkTQNLaV5uziNlbGE4w4UBX+yeJmWWTs=,tag:XsoCs/Ofe80XauG1HjoiBg==,type:str]
-  mon_initial_members: ENC[AES256_GCM,data:Vcq/c9w=,iv:YVqhlGOZzeICAunoEMXzgy7n96lGQSatZIOiSdZugBk=,tag:TGLAVoObhbU9zrIyWIZ0cA==,type:str]
+  mon_host: ENC[AES256_GCM,data:OrMbVxNHddf0KM2jxhkTNRAbUbSbRVAy3fYKl2CZQuTdP1IWILwYNUVszGwYsAlZUwBt7PxvgI8v498CRHZIYnLixx3m1XEnglw=,iv:4PZ+HslcuRYP+Xjni8P3j1t02Z3LfSzYjjbWqLzh28Q=,tag:jHiCimqn9qYJ47iNCaZR+w==,type:str]
+  mon_initial_members: ENC[AES256_GCM,data:BIsnzU0=,iv:7m75T5V6ebeqJl1BVLOTVO1uekDbUn/v30CjTVUNcJc=,tag:p+3Yc5GkVFvBJB0jMrrQQA==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMV3BYSFhTNXVXMHF6MzF1
-        Y3FEdGltaTUvc0lhUnFKUHhMQzJtcC9JQlNnClYyajl1UCtVOUxlbGFaVC94N3Bh
-        dWU3Skh5a1ZDTnB0OTd6dG9FNjFtbW8KLS0tIDZmNUpNZm5LSHRxZUlDSDNoSXhZ
-        KzA4bmJjTXArTkZvMVFoS08xSzFoTWMKOze2M2iTjTSpkBLOevA6D9cX33m7oWZv
-        HBV71Lr8yVX6CM4Kq0lBJaaGtlA6cSntIDo3EwAN3793ytbv9+JeKA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBib0owdnZSVk5kU1pwNmFy
+        VGVkWlBsaisrRTJHalJ6WnFkVW4vZGRGRVVvCmVrUytPdXVwYXRBT0dMN3BPZzlx
+        ejgzOTV2RmxwLzVZcExNTXRjeElETUEKLS0tIG8zMGlIbXNqWjd1SjB2d0JKUFlY
+        OEY3SHlaOHhIT0s5VEZBK0E2ZmZJK1UKrQR//EpzIoVuCzculQ/exsoFg9SZd47X
+        c4N2T2Isy5vZb3QKXS62w2zWbzmrLMw1Yszhx1RGeCJT2Aqe3Fpfww==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1ryhy9dduzk5hyn33lnm7swtg72r7luklfv397s3wmhqav099w95s3cu3rh
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-07-18T22:18:26Z"
-  mac: ENC[AES256_GCM,data:md5I/FEMQ+qsZnjqBNbD8Au+KmxTlFs4G/Sb7+OY+UsOomJ/OELtsRjKkZLUBEQftNj3vriih5BDaD+ZQKx3NzbognTLs6mkNMg64xCMjf0NLvYziMlZ8jArSLlqSAakLO+z+9lKhOQ1K0ONtX26UC2edjhDcldxSHEP0fXKb18=,iv:ZrFuQQht/n1XPgUBocN84tOcBmtEElcXZk2io5DN/+0=,tag:hnBkPrB1UpNWfmdZxAFnPQ==,type:str]
+  lastmodified: "2026-09-06T14:14:00Z"
+  mac: ENC[AES256_GCM,data:BhhAK1oVFWnGlFukaqG3dRYegtWiQa8cYYdu8ha4WGp39RG0wm1S2mjGdMFs9u5LICrl2N36u6bvmEMnZBRyC6JBAFFZiXSyaEIQi+FXaDMze/tt/yuRbP0CyDKvpIqSdL5yo0AGkxwM3DTqOQNva2HBYK4JnP6IqG7MAyGUm6U=,iv:mjY2dU93uMrfrv4qhe+UtXtPsZ1SixjhEuv0v6h+qOA=,tag:zxLDCc+IXxt5ajO9wEX8Nw==,type:str]
   mac_only_encrypted: true
-  version: 3.13.2
+  version: 3.13.3


### PR DESCRIPTION
## What

Rebuilds all six values in `ceph-secrets.sops.yaml` from the live `rook-ceph` Secrets and re-encrypts.

## Why

#3875 made the Secret decrypt for the first time — which exposed that **the stored `client.admin` key is dead.** It matches no current cephx entity at all.

Hash comparison against the live cluster (values never printed):

| Source | sha1 (first 16) |
|---|---|
| live `ceph auth get-key client.admin` | `e79b25bc75e360c2` |
| `system-upgrade/rook-ceph-mon` (stored) | `e17e9daed342945a` |
| `rook-ceph/rook-ceph-mon` (Rook's own) | `e79b25bc75e360c2` |

I also hashed every key in `ceph auth ls` and compared — **the stored key matches nothing**. It isn't a different valid user, it's a credential from a cluster state that no longer exists. Rook's own copy tracks live correctly; only the hand-maintained SOPS copy drifted.

Had this merged without the refresh, the hook would have failed a third time, on `EACCES` instead of a parse error.

## After this change

All six values hash-match live:

```
MATCH  rook-ceph-mon[ceph-secret]           sha=e79b25bc75e3
MATCH  rook-ceph-mon[ceph-username]         sha=d045fae83ff2
MATCH  rook-ceph-mon[fsid]                  sha=a5ea8ffa6167
MATCH  rook-ceph-mon[mon-secret]            sha=2e9d8d1880a9
MATCH  rook-ceph-config[mon_host]           sha=04537a76258d
MATCH  rook-ceph-config[mon_initial_members] sha=89a51e0c3e88
```

## Encryption

Encrypted with the repo's own rule from `.sops.yaml` via `sops --encrypt --in-place` — the exact step `just configure` runs (justfile lines 18–20). `just configure` itself can't run here (no `makejinja` in `.venv`), so the encryption step was used directly rather than skipped.

Guards applied while writing: the generator refuses to leave the file unencrypted, restores the original on any failure, and greps the result for plaintext in `ceph-secret` / `mon-secret` / `mon_host` before finishing. The committed blob has 8 `ENC[AES256_GCM` values and no plaintext — verified against `git show HEAD:...`, not just the working tree. `pre-commit` (including *Check for unencrypted Kubernetes secrets* and *Detect hardcoded secrets*) passes.

Values are also re-serialised through `yaml.safe_dump`, which fixes a latent quoting hazard: `mon_host` begins with `[` and parses as a YAML flow sequence unless quoted.

## Validation

| Step | Result |
|---|---|
| decrypt → hash-compare vs live | all 6 match |
| `pre-commit run --all-files` | all passed |
| `just flate-test` | 169 passed (1 pre-existing unrelated warning) |
| `scripts/find_mistakes.py` | 2 pre-existing warnings, unrelated |

## The bigger problem this points at

This is the **third** independent defect in the same hook path today (#3870 read-only `/tmp`, #3875 missing decryption, now dead credentials). All three were invisible until tuppr 0.5.2 started reporting hook failures.

Refreshing the key fixes today but restores a hand-maintained copy of the Ceph admin credential that drifted once and can drift again. The durable shape is to stop copying it: mirror `rook-ceph/rook-ceph-mon` into `system-upgrade` with an ExternalSecret using a `kubernetes`-provider `ClusterSecretStore`, which stays in sync automatically and removes the admin key from git entirely. Only `onepassword-connect` exists today, so that needs a new store plus RBAC — too much to bolt on while unblocking this upgrade. Worth its own issue.

Narrowing the hook from `client.admin` to a purpose-scoped Ceph user with just the caps for `osd set/unset noout` belongs in that same follow-up.

## After merge

Decrypting/refreshing a Secret doesn't bump the `TalosUpgrade` generation, so tuppr stays parked in terminal `Failed`. It needs the `tuppr.home-operations.com/reset` annotation to retry.

#3871 is still in effect (maintenance window off), so the retry fires immediately — and that revert is still owed once all three nodes reach v1.13.9.
