### PR TITLE
revert(tuppr): restore the Sunday 02:00 maintenance window

### DIFF
--- a/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/app/talos-upgrade.yaml
@@ -15,17 +15,11 @@ spec:
     timeout: 30m
     stage: false
   parallelism: 1
-  # TEMPORARY - REVERT AFTER THE v1.13.9 RUN COMPLETES.
-  # tuppr treats an absent maintenance block as "always allowed", so dropping
-  # the window lets the upgrade start as soon as Flux applies this, attended,
-  # instead of waiting for Sunday 02:00. The 2026-09-06 window was consumed by
-  # the failed pre-hook (see #3870) and the nodes are still on v1.13.6.
-  # Restore the block below as soon as all three report v1.13.9.
-  # maintenance:
-  #   windows:
-  #     - start: "0 2 * * 0"
-  #       duration: "4h"
-  #       timezone: "Europe/Paris"
+  maintenance:
+    windows:
+      - start: "0 2 * * 0"
+        duration: "4h"
+        timezone: "Europe/Paris"
   healthChecks:
     - apiVersion: v1
       kind: Node


### PR DESCRIPTION
## What

Reverts the temporary change from #3871, putting the `maintenance` block back.

Restores `talos-upgrade.yaml` **byte-for-byte** to its pre-#3871 state — verified with `diff` against `91e340265^`, not just by eye.

## Why now

The v1.13.9 upgrade completed successfully at **16:28**:

```
phase=Completed  msg=Successfully upgraded 3 nodes
done=["k8s-0","k8s-1","k8s-2"]  failed=

k8s-0  Talos v1.13.9  Ready  <no taint>
k8s-1  Talos v1.13.9  Ready  <no taint>
k8s-2  Talos v1.13.9  Ready  <no taint>

health: HEALTH_OK (muted: AUTH_INSECURE_* x3)
mon: 3 daemons, quorum a,b,c   mgr: a(active)   mds: 1/1 up, 1 hot standby
osd: 3 osds: 3 up, 3 in        pgs: 81 active+clean
flags sortbitwise,recovery_deletes,purged_snapdirs,pglog_hardlimit   ← noout gone
```

#3871 existed only to let that run start attended instead of waiting for Sunday. That's done, so the containment goes back on. Leaving it off is the actual risk: with no window, any future outdated node upgrades immediately at whatever hour Renovate bumps the Talos version.

## What today proved

The ceph hooks worked end-to-end for the first time since they were written in May. `noout` was set before the first reboot, held across all three, and was cleared by the post-hook — visible in the flag transitions throughout the run. That protection matters: with `size 2` pools across 3 hosts, one host down puts 34% of objects at single-replica, and without `noout` Ceph would have started re-replicating 63 GiB during a two-minute reboot, three times over.

It took three fixes to get there, each hidden behind the last:

| PR | Defect |
|---|---|
| #3870 | hook pods have `readOnlyRootFilesystem: true`; the hook wrote to `/tmp` |
| #3875 | `tuppr` Kustomization had no `decryption` block — Secret held raw `ENC[...]` |
| #3876 | the decrypted `client.admin` key was dead, matching no cephx entity |

All three were invisible until tuppr 0.5.2 (2026-08-27) started judging hook Jobs by the `JobFailed` condition.

## Also confirmed: the #3866 taint question

Every `tuppr.home-operations.com/outdated` taint **cleared itself** as its node completed — `findNextNodes` untaints completed nodes. A *successful* run cleans up after itself.

Stranding only happens when a run ends in a terminal state without completing, which is exactly what occurred three times today. That's useful evidence for the gate discussion in #3866: the taint is a reliable signal of *"a run started and did not finish"*, not of *"an upgrade is pending"*.

## Validation

| Step | Result |
|---|---|
| `diff` vs `91e340265^` | identical |
| `kubectl apply --dry-run=server` | `configured` |
| `just flate-test` | 169 passed |
| `pre-commit run --all-files` | all passed |

## Follow-ups worth their own issues

- **Stop hand-copying the Ceph admin key.** #3876 refreshed a credential that had already drifted once and can drift again. Mirroring `rook-ceph/rook-ceph-mon` via an ExternalSecret with a `kubernetes`-provider store keeps it in sync and removes the key from git.
- **Scope the hook off `client.admin`** to a purpose-built Ceph user with only the caps needed for `osd set/unset noout`.
- **#3866** — the taint evidence above.
