### PR TITLE
fix(gatus): repair the ceph health alert and cover tuppr upgrade failures

### DIFF
--- a/kubernetes/apps/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/config.yaml
@@ -45,16 +45,70 @@ endpoints:
     alerts:
       - type: pushover
 
+  # The mgr exports ceph_health_status without labels ("ceph_health_status 0.0"),
+  # so the old pattern *ceph_health_status{* 2* could never match and HEALTH_ERR
+  # was never actually alerted on. 0 = OK, 1 = WARN, 2 = ERR.
   - name: ceph-health
     group: infra
     url: http://rook-ceph-mgr.rook-ceph.svc.cluster.local:9283/metrics
     interval: 5m
     conditions:
       - "[STATUS] == 200"
-      - "[BODY] != pat(*ceph_health_status{* 2*)"
+      - "[BODY] != pat(*ceph_health_status 2*)"
     alerts:
       - type: pushover
         description: "Ceph cluster is in HEALTH_ERR"
+
+  # Three noisy auth checks are muted (see issue #3841), so a WARN that survives
+  # two hours is a real, non-recovering problem rather than routine churn. Pools
+  # are replicated size 2, so a single down OSD leaves no redundancy. The long
+  # threshold is what keeps a normal 3-node Talos roll from paging.
+  - name: ceph-health-degraded
+    group: infra
+    url: http://rook-ceph-mgr.rook-ceph.svc.cluster.local:9283/metrics
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY] != pat(*ceph_health_status 1*)"
+    alerts:
+      - type: pushover
+        description: "Ceph has been in HEALTH_WARN for over 2h and is not recovering"
+        failure-threshold: 24
+        success-threshold: 3
+
+  # tuppr sets noout before a Talos upgrade and clears it in a post-hook. If that
+  # post-hook fails the flag stays set, OSDs never get marked out, and degraded
+  # PGs are never re-replicated - silently, for as long as nobody looks. A full
+  # 3-node roll finishes well inside 5h, so anything longer is a stuck flag.
+  - name: ceph-noout-stuck
+    group: infra
+    url: http://rook-ceph-mgr.rook-ceph.svc.cluster.local:9283/metrics
+    interval: 15m
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY] != pat(*ceph_osd_flag_noout 1*)"
+    alerts:
+      - type: pushover
+        description: "Ceph noout has been set over 5h - a tuppr post-hook likely failed to clear it"
+        failure-threshold: 20
+        success-threshold: 1
+
+  # The tuppr chart ships PrometheusRules for exactly this, but nothing in the
+  # cluster evaluates PrometheusRule objects (no Prometheus, no vmalert), so they
+  # have never fired. Gatus is the only path to Pushover, so the check lives here.
+  # The phase pattern covers both TalosUpgrade and KubernetesUpgrade; the
+  # nodes_failed equality also catches the operator going away entirely.
+  - name: tuppr-upgrade
+    group: infra
+    url: http://tuppr-metrics-service.system-upgrade.svc.cluster.local:8081/metrics
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+      - "[BODY] != pat(*phase=\"Failed\"} 1*)"
+      - "[BODY] == pat(*tuppr_talos_upgrade_nodes_failed{name=\"cluster\"} 0*)"
+    alerts:
+      - type: pushover
+        description: "a tuppr upgrade has failed - Talos/Kubernetes upgrades are not progressing"
 
   - name: flux-health
     group: infra


### PR DESCRIPTION
## Why

Today's incident was three stacked defects in the tuppr Ceph hooks that had been broken since May.
The defects are fixed (#3870, #3875, #3876, #3878). This PR is about the other half of the problem:
**nothing told anyone.** The upgrade failed three times and it was only found because someone asked.

Looking into why surfaced two independent gaps.

### 1. The `ceph-health` alert could never fire

The condition was:

```yaml
- "[BODY] != pat(*ceph_health_status{* 2*)"
```

The mgr exports that metric **without labels**:

```
ceph_health_status 0.0
```

The literal string `ceph_health_status{` does not occur anywhere in the body (`grep -c` → `0`), so
the pattern cannot match — not even against a real `HEALTH_ERR`. Confirmed by replaying a faulted
body through the matcher:

```
OLD pattern *ceph_health_status{* 2*  vs HEALTH_ERR body -> False
NEW pattern *ceph_health_status 2*    vs HEALTH_ERR body -> True
```

Gatus's own history confirms it: the only recorded `ceph-health` failure in the last 50 checks was a
`[STATUS] (0) == 200` during a node reboot. The body condition has always reported success.

The labels seen in Grafana (`ceph_health_status{cluster="rook-ceph",...}`) are added by Alloy at
scrape time — Gatus reads the raw endpoint, which has none.

### 2. Nothing in the cluster evaluates PrometheusRule objects

The tuppr chart ships a perfectly good `TalosUpgradeFailed` rule. It has never fired, because there
is no Prometheus, no vmalert and no Alertmanager in the cluster:

| | |
|---|---|
| ServiceMonitors | 30 |
| PrometheusRules | 1 (`system-upgrade/tuppr`, from the chart) |
| Prometheus / vmalert / Alertmanager pods | **0** |
| Grafana alert rules | **0** |
| Grafana contact points | 1 default `email receiver`, unconfigured |
| Rook `createPrometheusRules` | `false` |

Metrics reach the external VM fine — `tuppr_talos_upgrade_phase` and `ceph_health_status` both query
successfully. The telemetry is good; only rule *evaluation* is missing. Gatus → Pushover is the only
notification path that actually works, so the checks belong there.

## What changed

All in `kubernetes/apps/observability/gatus/app/resources/config.yaml`:

| Endpoint | Catches |
|---|---|
| `ceph-health` *(fixed)* | `HEALTH_ERR` — now actually matches |
| `ceph-health-degraded` *(new)* | `HEALTH_WARN` sustained 2h |
| `ceph-noout-stuck` *(new)* | `noout` still set after 5h |
| `tuppr-upgrade` *(new)* | `Failed` phase or failed nodes |

`ceph-noout-stuck` is the one that matters most for durability. tuppr sets `noout` pre-upgrade and
clears it in a post-hook; if that post-hook fails the flag stays set, OSDs are never marked out, and
degraded PGs are never re-replicated — silently, indefinitely. With `replicated: size 2` pools that
is a real data-durability risk. tuppr does run post-hooks on failure paths
(`transitionToFinalize`), so this covers the post-hook itself failing.

## Every pattern was tested against live bodies

The lesson from today is that an untested assumption costs months, so the patterns were checked
against the real metrics endpoints — healthy, then with faults injected:

```
False  ceph-health ERR (want False now)          True  HEALTH_ERR       -> matches
False  ceph-health-degraded WARN (want False)    True  HEALTH_WARN      -> matches
False  ceph-noout (want False now)               True  noout set        -> matches
False  tuppr phase Failed (want False now)       True  talos Failed     -> matches
 True  tuppr nodes_failed==0 (want True now)    False  nodes_failed=1   -> stops matching
```

Reachability was verified too: `tuppr-metrics-service` returns HTTP 200 unauthenticated
cross-namespace, and there are no NetworkPolicies in `observability` or `system-upgrade`.

I also confirmed Gatus's `pat()` wildcards **do** cross `/` — the `flux-health` check's pattern
matched a `/`-heavy kube-state-metrics body at 14:26 today. Had it used `path.Match` semantics none
of these patterns would work.

## Thresholds, and why they are long

Both new Ceph checks deliberately use high failure thresholds so a normal Sunday Talos roll does not
page:

- `ceph-health-degraded`: 24 × 5m = **2h** sustained WARN. A 3-node roll dips into WARN routinely;
  two hours of it means it is not recovering.
- `ceph-noout-stuck`: 20 × 15m = **5h**. A full roll finishes well inside that (today's took ~1.5h),
  and the maintenance window itself is 4h.

The tradeoff is deliberate: these are tuned to catch *stuck* states, not transient ones. A genuinely
fast-moving Ceph failure is caught by `ceph-health` (HEALTH_ERR, threshold 3) instead.

## Not addressed here

Standing up real rule evaluation — vmalert against the external VM, or Grafana unified alerting with
a Pushover contact point — would let the tuppr chart's own PrometheusRules work as intended and
remove the need to hand-translate rules into Gatus probes. That is a larger change and wants its own
discussion; this PR restores coverage using infrastructure that already works. Happy to open an
issue for it if you want to pursue it.

## Validation

- `just flate-test` — 169 passed
- `pre-commit run --all-files` — all passed
- `python3 scripts/find_mistakes.py` — 2 pre-existing warnings, unrelated
- Pattern behaviour verified against live `rook-ceph-mgr` and `tuppr-metrics-service` bodies
- `just configure` / `just validate` could not run locally (no `makejinja` in `.venv`, no
  `yayamlls`) — pre-existing environment gap, CI covers both
