### PR TITLE
fix(observability): silence alerting, repair broken dashboards, scrape cAdvisor

### DIFF
--- a/kubernetes/apps/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/config.yaml
@@ -3,7 +3,13 @@ alerting:
   pushover:
     application-token: ${GATUS_PUSHOVER_APP_TOKEN}
     user-key: ${GATUS_PUSHOVER_USER_KEY}
-    priority: 1
+    # -1 delivers the notification immediately but with no sound and no
+    # vibration, so nothing here can wake anyone - alerts get read in the
+    # morning instead. This was 1 (high), which in Pushover explicitly
+    # bypasses Quiet Hours, so every check could alert at 3am.
+    priority: -1
+    # -2 puts recovery notices in the Pushover app with no alert at all.
+    resolved-priority: -2
     default-alert:
       description: healthcheck failed
       send-on-resolved: true

--- a/kubernetes/apps/observability/grafana-cloud/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana-cloud/app/helmrelease.yaml
@@ -48,6 +48,54 @@ spec:
             forward_to = [prometheus.remote_write.vm.receiver]
           }
 
+          // Kubelet cAdvisor - the source of every container CPU/memory series.
+          // Nothing was scraping it, which is why all pod/container resource
+          // panels rendered empty. Scraped directly on the kubelet's :10250
+          // rather than through the apiserver proxy, because the Alloy
+          // ClusterRole carries nodes/metrics but not nodes/proxy.
+          discovery.kubernetes "nodes" {
+            role = "node"
+          }
+
+          discovery.relabel "cadvisor" {
+            targets = discovery.kubernetes.nodes.targets
+            rule {
+              source_labels = ["__meta_kubernetes_node_name"]
+              target_label  = "node"
+            }
+            rule {
+              target_label = "__metrics_path__"
+              replacement  = "/metrics/cadvisor"
+            }
+          }
+
+          prometheus.scrape "cadvisor" {
+            targets           = discovery.relabel.cadvisor.output
+            job_name          = "kubelet-cadvisor"
+            scheme            = "https"
+            scrape_interval   = "60s"
+            bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+            tls_config {
+              ca_file              = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+              insecure_skip_verify = true
+            }
+            forward_to = [prometheus.relabel.cadvisor_keep.receiver]
+          }
+
+          // Keep only the series the dashboards actually query. Measured against
+          // the live endpoints: this keep-list is 6580 series across the 3 nodes
+          // where an unfiltered scrape is 39222. Against a ~72550 baseline that
+          // is +9% rather than +54%, which matters because the VM Prometheus is
+          // capped at 10GB retention and /data is already 87% full (issue #3726).
+          prometheus.relabel "cadvisor_keep" {
+            forward_to = [prometheus.remote_write.vm.receiver]
+            rule {
+              source_labels = ["__name__"]
+              regex         = "container_(cpu_usage_seconds_total|cpu_cfs_periods_total|cpu_cfs_throttled_periods_total|memory_working_set_bytes|memory_rss|memory_cache|network_receive_bytes_total|network_transmit_bytes_total|fs_reads_bytes_total|fs_writes_bytes_total)"
+              action        = "keep"
+            }
+          }
+
           // Blackbox probe targets for NFS health (replaces orphaned VMProbes)
           discovery.relabel "blackbox_nfs" {
             targets = [{

--- a/kubernetes/apps/observability/grafana/instance/grafanadashboards.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadashboards.yaml
@@ -290,7 +290,7 @@ spec:
   datasources:
     - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
-  url: https://raw.githubusercontent.com/kedacore/keda/main/config/grafana/kubescaler.json
+  url: https://raw.githubusercontent.com/kedacore/keda/main/config/grafana/keda-dashboard.json
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
@@ -305,7 +305,7 @@ spec:
   datasources:
     - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
-  url: https://raw.githubusercontent.com/cilium/cilium/main/examples/kubernetes/addons/prometheus/monitoring-example/dashboards/cilium.json
+  url: https://raw.githubusercontent.com/cilium/cilium/main/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-dashboard.json
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
@@ -327,6 +327,54 @@ spec:
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
+  name: kubernetes-namespaces
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  # renovate: depName="Kubernetes / Views / Namespaces"
+  url: https://grafana.com/api/dashboards/15758/revisions/46/download
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: kubernetes-nodes
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  # renovate: depName="Kubernetes / Views / Nodes"
+  url: https://grafana.com/api/dashboards/15759/revisions/40/download
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: kubernetes-pods
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: Prometheus
+      inputName: DS_PROMETHEUS
+  # renovate: depName="Kubernetes / Views / Pods"
+  url: https://grafana.com/api/dashboards/15760/revisions/39/download
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
   name: etcd
 spec:
   allowCrossNamespaceImport: true
@@ -337,7 +385,7 @@ spec:
     - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
   # renovate: depName="etcd"
-  url: https://grafana.com/api/dashboards/15055/revisions/9/download
+  url: https://grafana.com/api/dashboards/15055/revisions/7/download
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1

--- a/kubernetes/apps/observability/keda/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/keda/app/helmrelease.yaml
@@ -18,3 +18,14 @@ spec:
       retries: 3
   values:
     enableServiceLinks: false
+    # KEDA exposes metrics but ships no ServiceMonitor by default, so nothing
+    # was scraping it and the Grafana dashboard rendered empty panels. The
+    # chart can emit the ServiceMonitors itself, which is preferable to
+    # hand-maintaining them alongside the release.
+    prometheus:
+      metricServer:
+        serviceMonitor:
+          enabled: true
+      operator:
+        serviceMonitor:
+          enabled: true


### PR DESCRIPTION
## Why

Two problems, both found by actually querying the live stack rather than reading manifests.

**Alerting was configured to wake you up.** The Gatus Pushover provider was on `priority: 1` (high),
which in Pushover explicitly **bypasses Quiet Hours**. Every check — including the blog uptime probe
and the Ceph/tuppr checks from #3879 — could alert at 3am. The requirement is the opposite:
notifications should arrive silently and be read in the morning.

**Dashboards were missing data, and three were broken outright.**

| Finding | Evidence |
|---|---|
| 3 dashboards failing to sync | `cilium`, `etcd`, `keda` — all `InvalidSpec: 404`; `cilium` broken since **2026-07-13** |
| cAdvisor metrics entirely absent | `container_cpu_*` / `container_memory_*` returned `[]` |
| KEDA never scraped | `keda_.*` returned `[]` — `keda-operator-metrics-apiserver:8080` exists with no ServiceMonitor |

The cAdvisor gap is the root cause of the data-quality complaint: Alloy scraped only ServiceMonitors
and PodMonitors, and nothing scraped the kubelet. Every pod/container CPU and memory panel — including
in the existing `Kubernetes / Views / Global` dashboard — has been rendering empty.

## Two commits, separable

**1. `fix(gatus)` — silent alerting.** One block, no endpoint changes:

- `priority: -1` — arrives immediately, no sound, no vibration
- `resolved-priority: -2` — recovery notices land in the app with no alert

Gatus supports per-alert `provider-override` (confirmed against the v5.36.0 source) if a single check
ever needs to break through later. The mechanism is there, deliberately unused.

**2. `fix(observability)` — dashboards + metrics.**

| Dashboard | Was (404) | Now |
|---|---|---|
| `keda` | `config/grafana/kubescaler.json` | `keda-dashboard.json` (renamed upstream) |
| `cilium` | `monitoring-example/dashboards/` | `files/grafana-dashboards/cilium-dashboard.json` (moved) |
| `etcd` | `15055` revision **9** | revision **7** — 9 never existed, latest published is 7 |

Plus a kubelet cAdvisor scrape in Alloy, three new resource dashboards, and KEDA scraping.

## The cAdvisor keep-list is measured, not estimated

I sized it against the live endpoints rather than guessing:

| | Series across 3 nodes | On a 72,550 baseline |
|---|---|---|
| **Filtered keep-list** | **6,580** | **+9%** |
| Unfiltered scrape | 39,222 | +54% |

That gap matters: the VM Prometheus is capped at 10GB retention and `/data` is already 87% full
(#3726 Phase 4). The unfiltered version would cost real retention for metrics no dashboard queries.

Alloy's ClusterRole **already carried `nodes` and `nodes/metrics`** — unused — so this needs no RBAC
change. The scrape hits the kubelet directly on `:10250` rather than the apiserver proxy, because the
role has `nodes/metrics` but not `nodes/proxy`.

cAdvisor was confirmed live on the Talos kubelet before any of this was written, by reading
`/api/v1/nodes/k8s-0/proxy/metrics/cadvisor` directly.

## New dashboards

With container metrics flowing, adds three from `dotdc/grafana-dashboards-kubernetes` — the same
family as the `kubernetes-global` view already in use, so datasource templating and label
expectations already match:

| ID | Title | Answers |
|---|---|---|
| 15758 | Kubernetes / Views / Namespaces | which namespace is eating RAM/CPU |
| 15759 | Kubernetes / Views / Nodes | node pressure, allocatable vs usage |
| 15760 | Kubernetes / Views / Pods | per-pod/container top consumers |

This covers most of the "resource investigation" gap in #3726 Phase 3 with **no new components**.

## KEDA

Fixing the dashboard URL alone would have produced a dashboard with every panel empty, since KEDA was
never scraped. The chart can emit its own ServiceMonitors, which beats hand-maintaining them next to
the release — so this enables `prometheus.metricServer.serviceMonitor` and
`prometheus.operator.serviceMonitor` rather than adding a separate manifest.

## Risks

- **Series growth is real but bounded.** +9% measured. If the keep-list regex is wrong it becomes
  +54% — the verification step below is the guard, and it should be checked before this sits for long.
- **The kubelet `:10250` scrape may be rejected by the Talos kubelet.** If so, the fallback is the
  apiserver proxy path plus `nodes/proxy` on the Alloy ClusterRole — already proven to work, since
  that is how the endpoint was verified.
- **The alerting change cannot be fully proven without a real failure.** Values come from the verified
  v5.36.0 source; the first genuine alert arriving silently is the acceptance test.
- `keda` and `cilium` track `main` upstream and can 404 again if files move. Pre-existing; the
  dashboard sync-status check is how it gets caught.

## Verification

- `just flate-test` — 169 passed
- `pre-commit run --all-files` — all passed
- `python3 scripts/find_mistakes.py` — 2 pre-existing warnings, unrelated
- Rendered Alloy River config inspected after templating
- All three replacement dashboard URLs confirmed `200`
- `cilium_*` and `etcd_*` metrics confirmed present, so those two render with real data immediately

After merge I'll confirm: all dashboards report `DashboardSynchronized`, `container_memory_working_set_bytes`
returns data, total series lands near 79k **not** 112k, and `keda_.*` is non-empty.

## Not in scope

Alertmanager / rule evaluation stays deferred per the reasoning on
[#3726](https://github.com/axeII/home-ops/issues/3726#issuecomment-5561268600). Nothing here adds a
component.
