### PR TITLE
fix(observability): correct cilium dashboard URL and keda prometheus values

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/grafanadashboards.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadashboards.yaml
@@ -305,7 +305,7 @@ spec:
   datasources:
     - datasourceName: Prometheus
       inputName: DS_PROMETHEUS
-  url: https://raw.githubusercontent.com/cilium/cilium/main/examples/kubernetes/addons/prometheus/files/grafana-dashboards/cilium-dashboard.json
+  url: https://raw.githubusercontent.com/cilium/cilium/main/install/kubernetes/cilium/files/cilium-agent/dashboards/cilium-dashboard.json
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1

--- a/kubernetes/apps/observability/keda/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/keda/app/helmrelease.yaml
@@ -22,10 +22,16 @@ spec:
     # was scraping it and the Grafana dashboard rendered empty panels. The
     # chart can emit the ServiceMonitors itself, which is preferable to
     # hand-maintaining them alongside the release.
+    # Both levels are required: the chart templates gate on
+    # `and .Values.prometheus.<x>.enabled .Values.prometheus.<x>.serviceMonitor.enabled`
+    # and both default to false, so setting only serviceMonitor.enabled
+    # renders nothing at all.
     prometheus:
       metricServer:
+        enabled: true
         serviceMonitor:
           enabled: true
       operator:
+        enabled: true
         serviceMonitor:
           enabled: true


### PR DESCRIPTION
## Why

Post-merge verification of #3880 found two defects in that PR. Both are mine, and both are the kind
that pass a shallow check.

### 1. Cilium — HTTP 200 is not content validation

I verified the replacement URL returned `200` and stopped there. That path is a **symlink**, and
`raw.githubusercontent.com` serves the link *target* as plain text:

```
$ curl .../files/grafana-dashboards/cilium-dashboard.json
../../../../../../install/kubernetes/cilium/files/cilium-agent/dashboards/cilium-dashboard.json
```

So grafana-operator swapped one failure for another — from `404` to
`failed to extract model: invalid character '.' looking for beginning of value`.

Now points at the real file, which parses as JSON with 80 panels and 179 `${DS_PROMETHEUS}`
references matching the existing datasource mapping.

### 2. KEDA — set the child flag, not the parent

The chart templates gate on **both** levels:

```gotemplate
{{- if and .Values.prometheus.operator.enabled .Values.prometheus.operator.serviceMonitor.enabled }}
```

Both default to `false`. I set only `serviceMonitor.enabled`, so the values applied cleanly, the
HelmRelease reported `Helm upgrade succeeded`, and **zero ServiceMonitors were created** — no error
anywhere. The quiet kind of wrong.

## This time it is verified, not assumed

Rendered the chart with `flate build hr keda` rather than trusting the values:

```
total rendered resources: 25
ServiceMonitors: 2
  - keda-operator                    | selector: {app.kubernetes.io/name: keda-operator}
                                     | endpoints: [(metrics, /metrics)]
  - keda-operator-metrics-apiserver  | selector: {app.kubernetes.io/name: keda-operator-metrics-apiserver}
                                     | endpoints: [(metrics, /metrics)]
```

Then checked the part that would still have failed silently: `keda-operator`'s live Service has only
`metricsservice:9666` — no port named `metrics`, so the ServiceMonitor would have matched nothing.
Confirmed the chart adds it once the parent flag is on:

```
keda-operator
    port: metricsservice 9666 -> target 9666
    port: metrics        8080 -> target 8080   <- added by prometheus.operator.enabled
```

Selectors match live Service labels on both.

## What #3880 got right

Recording this so the follow-up is not mistaken for a rollback:

| Check | Result |
|---|---|
| cAdvisor metrics | exactly the 10 keep-list names, nothing else |
| Total series | **79,242** — predicted ~79k; ~112k would have meant the filter failed |
| Kubelet `:10250` scrape | worked on Talos, apiserver-proxy fallback not needed |
| Dashboards synced | 22 → 27 (`etcd`, `keda` fixed; 3 new resource views landed) |

The `container_memory_working_set_bytes` / `container_cpu_usage_seconds_total` series that every pod
and container panel depends on are now flowing for the first time.

## Validation

- `flate build hr keda` — ServiceMonitors render, selectors and ports confirmed against live Services
- Cilium JSON fetched and parsed — valid, 80 panels
- `just flate-test` — 169 passed
- `pre-commit run --all-files` — all passed
- `just configure` / `just validate` could not run locally (no `makejinja` in `.venv`, no `yayamlls`)
  — pre-existing environment gap, CI covers both

After merge I'll confirm all 28 dashboards report `DashboardSynchronized` and `keda_.*` returns data.
