### PR TITLE
fix(media): add startup probes so slow boots don't restart pods

### DIFF
--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -50,12 +50,27 @@ spec:
                     port: *port
                   initialDelaySeconds: 0
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  # 1s was too tight for this Node.js app and produced
+                  # recurring near-miss liveness timeouts under normal load.
+                  timeoutSeconds: 5
                   # High threshold tolerates ~150s of DNS blip (UniFi dnsmasq
                   # restarts) before Kubernetes kills the pod. The app doesn't
                   # crash — it just becomes unhealthy when DB DNS fails.
                   failureThreshold: 15
               readiness: *probes
+              # Holds liveness off until the app has actually booted: up to
+              # 5min (5s x 60) of startup grace, then liveness takes over.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v1/status
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
             resources:
               requests:
                 cpu: 10m

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -55,9 +55,22 @@ spec:
                     port: *port
                   initialDelaySeconds: 0
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  timeoutSeconds: 5
                   failureThreshold: 3
               readiness: *probes
+              # Boot waits on the postgres-init dependency and the NFS media
+              # mount. Allow up to 5min (5s x 60) before liveness applies.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
             resources:
               requests:
                 cpu: 10m

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -38,9 +38,22 @@ spec:
                     port: *port
                   initialDelaySeconds: 0
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  timeoutSeconds: 5
                   failureThreshold: 3
               readiness: *probes
+              # Allow up to 5min (5s x 60) for first boot and DB load before
+              # liveness starts killing the pod.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /status
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
## What

Adds a `startupProbe` to **seerr**, **sonarr**, and **tautulli**, and raises `liveness`/`readiness` `timeoutSeconds` from `1` → `5` on all three.

## Why

Investigation of the high restart counts on these pods found they all trace to a single event: node **`k8s-1` rebooted at 2026-09-06 14:23 UTC** (all four kubelet conditions — `Ready`, `MemoryPressure`, `DiskPressure`, `PIDPressure` — transitioned at that identical timestamp). Restart counts at the time:

| App | Restarts | Root cause |
|---|---|---|
| external-dns-unifi | 10 | node reboot + webhook sidecar startup race |
| tautulli | 8 | node reboot recreate cycle |
| sonarr | 7 | node reboot, compounded by Postgres dependency also recovering |
| seerr | 3 | node reboot (SIGTERM on eviction) |

None of these were application defects. But **none of the three app-template workloads had a `startupProbe`**, so the liveness probe applied from the first second of container life. That turns a legitimately slow cold start into a kill-and-restart loop — which is what inflated the counts rather than the pods simply taking their time to boot.

Sonarr additionally waits on its `postgres-init` initContainer and an NFS media mount; seerr waits on its Postgres DB. Both can legitimately exceed the old effective window on a cold start.

### Separately: seerr's liveness timeout was too tight

`get_events` showed a recurring `Liveness probe failed: context deadline exceeded (Client.Timeout exceeded while awaiting headers)` with **count 13**, most recent **today** — near-misses that never crossed `failureThreshold: 15`, so no restart, but steadily accumulating. CPU usage was checked and is trivially low (~0.2–0.5%, no throttling), so this was not resource starvation — `timeoutSeconds: 1` is simply too tight for a Node.js app. Left unaddressed it could eventually cross the threshold and cause a real outage.

## Changes

Each of the three gets:

```yaml
startup:
  enabled: true
  custom: true
  spec:
    httpGet: { path: <same as liveness>, port: <same as liveness> }
    initialDelaySeconds: 0
    periodSeconds: 5
    timeoutSeconds: 5
    failureThreshold: 60   # 5min of boot grace, then liveness takes over
```

plus `timeoutSeconds: 1` → `5` on liveness/readiness.

**Unchanged:** probe paths, ports, and seerr's `failureThreshold: 15` (its ~150s UniFi dnsmasq DNS-blip tolerance, documented in an existing comment).

## Validation

- `just validate` — exit 0 (only the known `token.sops.yaml` third-party schema noise)
- `just flate-test` — **169 passed**; sole warning is pre-existing on `external-dns-cloudflare`, unrelated
- `flate build hr` — confirmed the chart actually renders all three `startupProbe`s into the Deployment specs with correct paths/ports
- `python3 scripts/find_mistakes.py` — exit 0, only the 2 documented clean-tree warnings (`affine`, `rook-ceph`)
- `pre-commit run --all-files` — all hooks passed

⚠️ `just configure` could **not** run: `.venv/bin/makejinja: No such file or directory`. The local `.venv` is a bare Python 3.9 venv containing only `pip`, and there is no `pyproject.toml`/`requirements.txt` to restore it from. This is a pre-existing broken local bootstrap independent of file contents — **not** introduced by this change. This change touches no templates and no secrets, and step 1's third action (`yayamlls validate kubernetes/`) is covered by `just validate` above. Worth fixing separately.

## Risk / cautions

Low. Probe-only tuning, no image, resource, or storage changes. A `startupProbe` is strictly more permissive during boot than the current behaviour — worst case a genuinely wedged pod now takes up to 5min to be killed instead of ~30s. Rollout is a normal Deployment restart per app.

## Not addressed here

**external-dns-unifi** (`kubernetes/apps/network/external-dns/unifi/helmrelease.yaml`) is deliberately left alone. Its failure mode is genuinely different: the main `external-dns` container **fatal-exits** with `failed to connect to webhook: ... connection refused` when it races the `webhook` sidecar on simultaneous cold start (`Recreate` strategy). That is a process exiting on its own, not a probe killing it — a `startupProbe` would not help. It self-heals via restart backoff and has been stable for 21h. Worth a separate look if it recurs.

## Follow-up already done

All four pods were rotated with `kubectl rollout restart` to clear the stale restart counters. They came back `Running` with `0` restarts on `k8s-2`.
