### PR TITLE
fix(justfile): drop vestigial makejinja call so `just configure` runs

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,11 +10,10 @@ _default:
 
 # ─── Configure / Validate ────────────────────────────────────────────────────
 
-# Render templates, check secrets, and validate manifests
+# Encrypt any plaintext secrets and validate manifests
 configure:
     #!/usr/bin/env bash
     set -euo pipefail
-    .venv/bin/makejinja
     for file in $(find kubernetes -type f -name "*.sops.*"); do
         if sops filestatus "$file" | jq --exit-status ".encrypted == false" &>/dev/null; then
             sops --encrypt --in-place "$file"
@@ -326,12 +325,6 @@ brew:
 # Allow direnv
 direnv:
     direnv allow .
-
-# Set up Python virtual environment
-venv:
-    python3 -m venv .venv
-    .venv/bin/python3 -m pip install --upgrade pip setuptools wheel
-    .venv/bin/python3 -m pip install --upgrade --requirement requirements.txt
 
 # ─── Pre-commit ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

`just configure` — step 1 of the documented validation pipeline — failed immediately:

```
/var/folders/.../configure: line 17: .venv/bin/makejinja: No such file or directory
error: recipe `configure` failed with exit code 127
```

The local `.venv` is a bare Python 3.9 venv containing only `pip`. `just venv` could not rebuild it either, because it installs from a `requirements.txt` that does not exist.

## Root cause

This is **not** a broken local venv that needs repairing — it's dead code inherited from the upstream cluster-template that never worked in this repo:

- `git log --all -- makejinja.toml requirements.txt` → **empty**. Neither file has ever been tracked here.
- `find . -name '*.j2'` → **0 results**. There are no templates for makejinja to render.
- Installing makejinja does **not** fix it. Verified against makejinja 1.9.9 in a throwaway venv: with no `makejinja.toml` and no `--output`, it exits on `Missing option '--output' / '-o'`. So "fix the venv" by reinstalling was never going to make `just configure` work.

The `clean` recipe's `mv makejinja.toml .private/...` line is the tell — this repo was templated and the template machinery was dropped, but the `configure` recipe kept calling into it.

## Change

**`configure`** — remove the `makejinja` line. The two remaining steps are the ones that do real work, and both still run:
1. auto-encrypt any plaintext `*.sops.*` file
2. `yayamlls validate kubernetes/`

Comment updated from "Render templates, check secrets, and validate manifests" to match what it actually does.

**`venv` recipe** — removed entirely. All four `scripts/*.py` import stdlib only (`os`, `sys`, `re`, `json`, `subprocess`, `socket`, `pathlib`, `getpass`), so the repo needs no Python venv. Keeping a recipe that installs from a nonexistent `requirements.txt` is a trap.

## Blast radius

Nothing in `.github/workflows/` or `.pre-commit-config.yaml` references `just configure`, `makejinja`, `venv`, or `requirements.txt` — grep confirms zero hits. This is local-tooling only; CI is unaffected.

## Validation

- `just --list` parses cleanly (exit 0)
- **`just configure` now exits 0** — output is only the known `token.sops.yaml` third-party schema noise already documented in the `flux-validate` skill
- `git status` after the run confirms the sops loop rewrote **no** secret files
- `pre-commit run --all-files` — all hooks passed

Steps 2–4 of the chain don't apply (no changes under `kubernetes/` or `talos/`).

## Note

`.envrc` still does `PATH_add ./.venv/bin` and exports `VIRTUAL_ENV`. Left alone deliberately — `PATH_add` on a missing dir is a no-op and nothing reads `VIRTUAL_ENV` here, so it's inert, and touching `.envrc` would force a `direnv allow` re-approval. Worth tidying separately if you want. The stale `.venv/` directory is gitignored and can be deleted at your leisure.
