### PR TITLE
chore(claude): update gitbutler skill to 0.22.3

### DIFF
--- a/.claude/skills/gitbutler/SKILL.md
+++ b/.claude/skills/gitbutler/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: but
-version: 0.22.2
+version: 0.22.3
 description: "Commit, push, branch, and manage version control with GitButler. Use for commits, selective dirty-file or hunk commits, branches, diffs, PRs, history edits, squashes, amends, undo, merge, apply, and unapply. For selected dirty files or hunks, inspect with `but diff`; use compact `but status` for commit order, branch/stack placement, or conflict overview; use `but status -fv` when file/hunk IDs or per-commit file details matter. Replaces git write commands."
 author: GitButler Team
 ---


### PR DESCRIPTION
The `but` CLI reported the vendored skill was out of date and instructed running `but skill check --update`, which bumped `.claude/skills/gitbutler/SKILL.md` from `0.22.2` → `0.22.3`.

Version field only — the skill body is unchanged.

Split out from #3886 so each change can be reviewed independently.

Validation: `pre-commit run --all-files` passed (including the `Copilot agents match .claude/agents` hook).
