### PR TITLE
fix(validation): exempt volsync pvc.yaml from strict schema checks

### DIFF
--- a/.github/workflows/yayamlls.yaml
+++ b/.github/workflows/yayamlls.yaml
@@ -4,9 +4,16 @@ name: Yayamlls
 on:
   pull_request:
     branches: ["main"]
-    # mise.toml pins yayamlls itself, so a version bump must re-run this gate —
-    # it changes no manifest and would otherwise skip validation entirely.
-    paths: ["kubernetes/**", "mise.toml", ".github/workflows/yayamlls.yaml"]
+    # Beyond the manifests, anything that governs how yayamlls behaves must
+    # re-run this gate: mise.toml pins the binary, and the config and schemas
+    # decide what it accepts. None of those change a manifest, so without
+    # listing them here a bump or a rule change would skip validation entirely.
+    paths:
+      - "kubernetes/**"
+      - "mise.toml"
+      - ".yayamlls.yaml"
+      - ".yayamlls-schemas/**"
+      - ".github/workflows/yayamlls.yaml"
 
 jobs:
   validate:

--- a/.yayamlls.yaml
+++ b/.yayamlls.yaml
@@ -9,6 +9,7 @@ schemas:
     - "**/sops-age.sops.yaml"
     - "**/talsecret.sops.yaml"
     - "**/volsync/externalsecret.yaml"
+    - "**/volsync/pvc.yaml"
     - "**/volsync/replicationdestination.yaml"
     - "**/volsync/replicationsource.yaml"
     - "**/dragonfly/cluster/cluster.yaml"


### PR DESCRIPTION
Unblocks **#3894** (`yayamlls 0.1.11 → 0.3.0`), which currently fails `Yayamlls - Validate`.

## The failure

```
kubernetes/components/volsync/pvc.yaml:13:17: yayamlls value must be one of
'ReadOnlyMany', 'ReadWriteMany', 'ReadWriteOnce', 'ReadWriteOncePod'
  (at /spec/accessModes/0)
```

It's a **false positive**. Line 13 is:

```yaml
accessModes: ["${VOLSYNC_ACCESSMODES:=ReadWriteOnce}"]
```

A Flux post-build substitution that resolves to a valid value at apply time. yayamlls 0.3.0 validates the raw placeholder against the schema enum; 0.1.11 did not. Nothing is actually broken in the cluster.

## The fix

Map the file to `.yayamlls-schemas/any.json` — the escape hatch this repo **already uses** for the sibling volsync files carrying the same kind of substitution:

```yaml
  .yayamlls-schemas/any.json:
    ...
    - "**/volsync/externalsecret.yaml"
+   - "**/volsync/pvc.yaml"
    - "**/volsync/replicationdestination.yaml"
    - "**/volsync/replicationsource.yaml"
```

One line, consistent with the existing pattern.

## Verification

Run against the real 0.3.0 binary locally:

| | exit |
|---|---|
| yayamlls 0.1.11, before | 0 |
| yayamlls **0.3.0**, before | **1** ← the CI failure |
| yayamlls **0.3.0**, after | **0** |

The remaining `token.sops.yaml` message is the known third-party schema noise (`LeShaunJ/ops-schema` serving a non-JSON body) and stays non-fatal.

`just validate`, `just flate-test` (169 passed) and `pre-commit` all pass.

## Note

This is the merge gate working as intended. Before the mise migration added `mise.toml` to the workflow triggers, a tool bump like #3894 changed no manifest and would have run **neither** gate — auto-merging on the 2-day patch rule with a broken validator. Instead it failed loudly.
