### PR TITLE
fix(renovate): cap talosctl at the cluster's Talos minor

### DIFF
--- a/.renovate/allowedVersions.json5
+++ b/.renovate/allowedVersions.json5
@@ -6,5 +6,19 @@
       matchPackageNames: ["/postgresql/"],
       allowedVersions: "<=17",
     },
+    {
+      // talosctl is a client for the cluster pinned in talos/talenv.yaml. Talos
+      // tolerates a minor of client skew, but leaving it free means the client
+      // silently leads the cluster (it proposed 1.14.0 against a v1.13.10
+      // cluster). Cap it at the cluster's minor so an upgrade is a deliberate,
+      // reviewed step rather than a side effect.
+      //
+      // KEEP IN LOCKSTEP with talosVersion in talos/talenv.yaml: when the
+      // cluster moves to v1.14.x, raise this to "<1.15".
+      description: "Hold talosctl at the cluster's Talos minor (talenv.yaml)",
+      matchManagers: ["mise"],
+      matchPackageNames: ["/talosctl/", "/siderolabs\\/talos/"],
+      allowedVersions: "<1.14",
+    },
   ],
 }

--- a/scripts/find_mistakes.py
+++ b/scripts/find_mistakes.py
@@ -10,6 +10,7 @@ Catches common mistakes before Flux applies them to the cluster:
 - Component paths that don't exist
 - dependsOn referencing Kustomizations that aren't defined
 - Duplicate resource references in kustomizations
+- talosctl/kubectl pins drifting from the cluster versions they talk to
 """
 
 import sys
@@ -19,6 +20,8 @@ import re
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 APPS_DIR = ROOT / "kubernetes" / "apps"
 FLUX_DIR = ROOT / "kubernetes" / "flux"
+MISE_TOML = ROOT / "mise.toml"
+TALENV = ROOT / "talos" / "talenv.yaml"
 
 errors: list[str] = []
 warnings: list[str] = []
@@ -377,6 +380,39 @@ def check_common_component():
             continue
         if "components/common" not in content:
             warnings.append(f"Missing common component: {rel(ns_kustomization)}")
+
+
+def check_client_tool_versions():
+    """Client tools in mise.toml must match the cluster in talos/talenv.yaml.
+
+    talosctl and kubectl are pinned in mise.toml; the cluster they talk to is
+    pinned in talos/talenv.yaml. Renovate groups them so they move together, and
+    .renovate/allowedVersions.json5 stops talosctl leading the cluster. This
+    catches the remaining case: one side bumped without the other, which the
+    allowedVersions cap cannot see.
+    """
+    if not MISE_TOML.exists() or not TALENV.exists():
+        return
+    try:
+        mise = MISE_TOML.read_text()
+        talenv = TALENV.read_text()
+    except OSError:
+        return
+
+    pairs = [
+        ("talosctl", r'^talosctl\s*=\s*"([^"]+)"', r"^talosVersion:\s*v?(\S+)"),
+        ("kubectl", r'^kubectl\s*=\s*"([^"]+)"', r"^kubernetesVersion:\s*v?(\S+)"),
+    ]
+    for tool, tool_re, cluster_re in pairs:
+        pinned = re.search(tool_re, mise, re.MULTILINE)
+        cluster = re.search(cluster_re, talenv, re.MULTILINE)
+        if not pinned or not cluster:
+            continue
+        if pinned.group(1) != cluster.group(1):
+            errors.append(
+                f"{tool} is {pinned.group(1)} in mise.toml but the cluster is "
+                f"{cluster.group(1)} in talos/talenv.yaml - bump both together"
+            )
 
 
 # ── Main ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #3896. Grouping made the client/cluster skew **visible** — #3834 now pairs `talosctl 1.14.0` with a `v1.13.10` cluster in one diff — but visibility isn't prevention. This enforces it.

## Two layers

**1. `allowedVersions` cap** (`.renovate/allowedVersions.json5`)

```json5
{
  description: "Hold talosctl at the cluster's Talos minor (talenv.yaml)",
  matchManagers: ["mise"],
  matchPackageNames: ["/talosctl/", "/siderolabs\\/talos/"],
  allowedVersions: "<1.14",
}
```

Renovate can no longer propose talosctl ahead of the cluster. A Talos minor upgrade becomes a deliberate step instead of arriving as a client bump.

**2. A consistency check, because the cap will rot**

The cap is a static string that must be raised whenever `talosVersion` moves. That's a comment nobody reads on the day it matters — and if it's forgotten, talosctl silently *lags* the cluster instead, which is the same problem inverted.

So `find_mistakes.py` now compares the pins directly against the cluster:

| `mise.toml` | must equal | `talos/talenv.yaml` |
|---|---|---|
| `talosctl` | ↔ | `talosVersion` |
| `kubectl` | ↔ | `kubernetesVersion` |

This catches exactly what `allowedVersions` cannot see: one side bumped without the other, or a stale cap after an upgrade.

## Verification

Run against #3834's actual contents:

| Scenario | Result |
|---|---|
| talosctl `1.14.0`, cluster `v1.13.10` (#3834 today) | ❌ `exit 1` — *"talosctl is 1.14.0 in mise.toml but the cluster is 1.13.10 in talos/talenv.yaml - bump both together"* |
| talosctl `1.13.10`, cluster `v1.13.10` | ✅ `exit 0` |
| kubectl `1.37.0`, k8s `v1.37.0` | ✅ passes — already agree |
| current `main` | ✅ `exit 0`, only the 2 documented warnings |

`just validate`, `just flate-test` (169 passed) and `pre-commit` all pass.

## Severity note

`find_mistakes.py` isn't referenced by any workflow, `.pre-commit-config.yaml`, or the justfile — it's invoked manually per `AGENTS.md`. So the new **error** is a strong local signal, not a merge blocker. Say the word if you'd rather it were a warning, or wired into CI as a real gate.

## Merge order matters

Merge **this** before #3834. Renovate will then regenerate #3834 with `talosctl 1.13.10` on its next run. If #3834 merges first, `1.14.0` lands and Renovate won't downgrade it — you'd be capped at a version you're already past.

I'm also pinning #3834's branch to `1.13.10` directly so the ordering can't bite either way.

## Upgrade runbook (for when you do go to v1.14)

1. Raise the cap to `"<1.15"` here.
2. Let the grouped Renovate PR bump `talenv.yaml`, both tuppr CRs, and both mise pins together.
3. `python3 scripts/find_mistakes.py` — exit 0 confirms client and cluster agree before tuppr touches a node.
