### PR TITLE
fix(sabnzbd): raise memory limit to 4Gi to prevent OOMKill loop

### DIFF
--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
               requests:
                 cpu: 100m
               limits:
-                memory: 2.5Gi
+                memory: 4Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## What
Raises `controllers.sabnzbd.containers.app.resources.limits.memory` from `2.5Gi` to `4Gi` in `kubernetes/apps/media/sabnzbd/app/helmrelease.yaml`. Requests are unchanged (`cpu: 100m`, no memory request set).

## Why
sabnzbd crash-looped 96 times over ~8.5 hours (2026-09-11, ~07:04-15:28 UTC), OOMKilled (exit 137) each time. Root cause: it was extracting a large DVD9-image release with 7-Zip (`Ghost.in.the.Shell.Stand.Alone.Complex.VOL02...7z`), and LZMA2 decompression exceeded the 2.5Gi container memory limit. Because sabnzbd persists its post-processing queue to the config PVC, it retried the same job on every restart, driving the loop. It self-resolved when sabnzbd exhausted its own retry count and gave up on the job at 15:28:33 UTC - the pod has been stable since.

This is a mitigation (more headroom for large-archive extraction), not a guaranteed fix - a sufficiently large solid archive could still exceed any static limit.

## Risk
- Scope: `media` namespace, `sabnzbd` HelmRelease only. No RBAC, storage, or networking changes.
- Flux will restart the sabnzbd pod on reconcile to pick up the new resource limit (brief downtime, no data loss - queue/config persists on PVC as before).
- Raises the node's worst-case memory reservation for this pod by 1.5Gi; worth confirming node headroom if sabnzbd runs alongside other memory-heavy pods.

## Validation
Kubernetes manifests changed, so the full pipeline ran:
- `just configure` - passed (exit 0); one known-noise line for `token.sops.yaml` referencing an unreachable third-party schema URL (documented pre-existing issue, unrelated to this change)
- `just validate` - passed (exit 0), same known-noise line
- `just flate-test` - passed, 169 resources rendered ok (one pre-existing unrelated warning: `network/external-dns-cloudflare` "values not used by the chart")
- `python3 scripts/find_mistakes.py` - exit 0, only the two pre-existing expected warnings (unregistered `affine` app, missing common component in `rook-ceph`), neither related to this change
- `pre-commit run --all-files` - all hooks passed

Note: the working tree also had an unrelated pre-existing modification to `scripts/find_mistakes.py` at session start. That change was left untouched and is not included in this PR.
