### PR TITLE
chore(validation): consolidate YAML schemas on k8s-schemas.home-operations.com

### DIFF
--- a/.yayamlls.yaml
+++ b/.yayamlls.yaml
@@ -3,12 +3,21 @@ kubernetes:
   enabled: true
 catalog: true
 schemas:
+  # `.yayamlls-schemas/any.json` is literally `{}` — mapping a file to it is how a
+  # document is exempted from validation. Keep this list as short as possible and
+  # always record why an entry is here.
   .yayamlls-schemas/any.json:
-    - "**/secret.sops.yaml"
-    - "**/cluster-secrets.sops.yaml"
-    - "**/sops-age.sops.yaml"
-    - "**/talsecret.sops.yaml"
+    # SOPS-encrypted documents cannot be validated: the payload is ciphertext and
+    # the `sops` block is not part of any upstream schema. The glob also stops the
+    # SchemaStore catalog matching on filename alone — it was resolving
+    # token.sops.yaml to an unrelated 1Password schema and failing to load it.
+    - "**/*.sops.yaml"
+    # Flux postBuild substitutions sit in typed fields in these four:
+    # `${VOLSYNC_PUID:=1000}` in an integer `runAsUser`, `${VOLSYNC_CAPACITY:=5Gi}`
+    # in a quantity, `${APP}-volsync-secret` in a DNS-pattern field. A correct
+    # schema rejects all of those pre-substitution, so the *source* is exempt and
+    # the real coverage comes from `yayamlls validate --render`, which validates
+    # the rendered output with substitutions applied.
     - "**/volsync/externalsecret.yaml"
     - "**/volsync/replicationdestination.yaml"
     - "**/volsync/replicationsource.yaml"
-    - "**/dragonfly/cluster/cluster.yaml"

--- a/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cert-manager.io/clusterissuer_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cert-manager.io/clusterissuer_v1.json
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/dragonflydb.io/dragonfly_v1alpha1.json
 apiVersion: dragonflydb.io/v1alpha1
 kind: Dragonfly
 metadata:

--- a/kubernetes/apps/database/dragonfly/ks.yaml
+++ b/kubernetes/apps/database/dragonfly/ks.yaml
@@ -20,7 +20,7 @@ spec:
   timeout: 5m
   wait: true
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/database/pgbackup/app/externalsecret.yaml
+++ b/kubernetes/apps/database/pgbackup/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kochhaus-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/default/affine/app/externalsecret.yaml
+++ b/kubernetes/apps/default/affine/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kochhaus-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/default/atuin/app/externalsecret.yaml
+++ b/kubernetes/apps/default/atuin/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/default/docmost/app/externalsecret.yaml
+++ b/kubernetes/apps/default/docmost/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kochhaus-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/default/home-assistant/app/externalsecret.yaml
+++ b/kubernetes/apps/default/home-assistant/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kochhaus-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/default/karakeep/app/externalsecret.yaml
+++ b/kubernetes/apps/default/karakeep/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/default/minecraft/app/externalsecret.yaml
+++ b/kubernetes/apps/default/minecraft/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://crd.movishell.pl/external-secrets.io/externalsecret_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/default/minecraft/app/helmrelease.yaml
+++ b/kubernetes/apps/default/minecraft/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://crd.movishell.pl/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/default/minecraft/app/mc-router-helmrelease.yaml
+++ b/kubernetes/apps/default/minecraft/app/mc-router-helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://crd.movishell.pl/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/default/minecraft/app/mc-router-repository.yaml
+++ b/kubernetes/apps/default/minecraft/app/mc-router-repository.yaml
@@ -1,5 +1,5 @@
 ---
-# yayamlls-disable-file
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/default/minecraft/app/repository.yaml
+++ b/kubernetes/apps/default/minecraft/app/repository.yaml
@@ -1,5 +1,5 @@
 ---
-# yayamlls-disable-file
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/default/minecraft/app/scaledobject.yaml
+++ b/kubernetes/apps/default/minecraft/app/scaledobject.yaml
@@ -1,5 +1,5 @@
 ---
-# yayamlls-disable-file
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/keda.sh/scaledobject_v1alpha1.json
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/kubernetes/apps/default/paperless/app/externalsecret.yaml
+++ b/kubernetes/apps/default/paperless/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/default/paperless/app/kustomization.yaml
+++ b/kubernetes/apps/default/paperless/app/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/kustomization.json
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/kubernetes/apps/default/paperless/ks.yaml
+++ b/kubernetes/apps/default/paperless/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/external/proxmox/ks.yaml
+++ b/kubernetes/apps/external/proxmox/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/external/truenas/ks.yaml
+++ b/kubernetes/apps/external/truenas/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/flux-system/flux-instance/app/httproute.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/httproute.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/kube-system/cilium/app/networks.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliumloadbalancerippool_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumloadbalancerippool_v2.json
 apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
@@ -9,7 +9,7 @@ spec:
   blocks:
     - cidr: "192.168.69.0/24"
 ---
-# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliuml2announcementpolicy_v2alpha1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliuml2announcementpolicy_v2alpha1.json
 apiVersion: cilium.io/v2alpha1
 kind: CiliumL2AnnouncementPolicy
 metadata:

--- a/kubernetes/apps/kube-system/cilium/gateway/certificate.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/certificate.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cert-manager.io/certificate_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cert-manager.io/certificate_v1.json
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/kubernetes/apps/kube-system/cilium/gateway/external.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/external.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/gateway_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/gateway_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:

--- a/kubernetes/apps/kube-system/cilium/gateway/internal.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway/internal.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/gateway_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/gateway_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:

--- a/kubernetes/apps/kube-system/csi-driver-nfs/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/csi-driver-nfs/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
@@ -13,7 +13,7 @@ spec:
     tag: 4.13.4
   url: oci://ghcr.io/home-operations/charts-mirror/csi-driver-nfs
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/kube-system/csi-driver-nfs/ks.yaml
+++ b/kubernetes/apps/kube-system/csi-driver-nfs/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/kube-system/external-secrets/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/axeII/crds/main/helmrelease_v2beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/kube-system/external-secrets/ks.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -25,7 +25,7 @@ spec:
   retryInterval: 1m
   timeout: 5m
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/kube-system/external-secrets/stores/kustomization.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/axeII/crds/main/kustomization_v1.json
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kube-system

--- a/kubernetes/apps/kube-system/external-secrets/stores/onepassword/kustomization.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/onepassword/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/axeII/crds/main/kustomization_v1.json
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kube-system

--- a/kubernetes/apps/kube-system/intel-device-plugin-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin-operator/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
@@ -13,7 +13,7 @@ spec:
     tag: 0.34.1
   url: oci://ghcr.io/home-operations/charts-mirror/intel-device-plugins-operator
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/kube-system/intel-device-plugin-operator/gpu/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin-operator/gpu/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
@@ -13,7 +13,7 @@ spec:
     tag: 0.34.1
   url: oci://ghcr.io/home-operations/charts-mirror/intel-device-plugins-gpu
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/kube-system/intel-device-plugin-operator/ks.yaml
+++ b/kubernetes/apps/kube-system/intel-device-plugin-operator/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -25,7 +25,7 @@ spec:
   targetNamespace: *namespace
   timeout: 5m
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/media/komga/ks.yaml
+++ b/kubernetes/apps/media/komga/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://lds-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/observability/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/observability/blackbox-exporter/app/repository.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/repository.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/observability/blackbox-exporter/ks.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/observability/etcd-scrape/servicemonitor.yaml
+++ b/kubernetes/apps/observability/etcd-scrape/servicemonitor.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/servicemonitor_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/kubernetes/apps/observability/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/observability/grafana/app/repository.yaml
+++ b/kubernetes/apps/observability/grafana/app/repository.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafana.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafana_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafana_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:

--- a/kubernetes/apps/observability/grafana/instance/grafanadashboards.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadashboards.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -15,7 +15,7 @@ spec:
   # renovate: depName="Prometheus Blackbox Exporter"
   url: https://grafana.com/api/dashboards/7587/revisions/3/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -31,7 +31,7 @@ spec:
   # renovate: depName="Cert-manager-Kubernetes"
   url: https://grafana.com/api/dashboards/20842/revisions/3/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -47,7 +47,7 @@ spec:
   # renovate: depName="Cloudflare Tunnels (cloudflared)"
   url: https://grafana.com/api/dashboards/17457/revisions/6/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -63,7 +63,7 @@ spec:
   # renovate: depName="External-dns"
   url: https://grafana.com/api/dashboards/15038/revisions/3/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -78,7 +78,7 @@ spec:
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/external-secrets/external-secrets/main/docs/snippets/dashboard.json
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -93,7 +93,7 @@ spec:
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/TwiN/gatus/master/.examples/docker-compose-grafana-prometheus/grafana/provisioning/dashboards/gatus.json
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -109,7 +109,7 @@ spec:
   # renovate: depName="Node Exporter Full"
   url: https://grafana.com/api/dashboards/1860/revisions/45/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -124,7 +124,7 @@ spec:
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/master/examples/grafana-dashboard.json
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -140,7 +140,7 @@ spec:
   # renovate: depName="Spegel"
   url: https://grafana.com/api/dashboards/18089/revisions/1/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -156,7 +156,7 @@ spec:
   # renovate: depName="Unpackerr"
   url: https://grafana.com/api/dashboards/18817/revisions/1/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -172,7 +172,7 @@ spec:
   # renovate: depName="VolSync Dashboard"
   url: https://grafana.com/api/dashboards/21356/revisions/3/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -187,7 +187,7 @@ spec:
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/2842/revisions/17/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -202,7 +202,7 @@ spec:
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/5336/revisions/9/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -217,7 +217,7 @@ spec:
       inputName: DS_PROMETHEUS
   url: https://grafana.com/api/dashboards/5342/revisions/9/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -232,7 +232,7 @@ spec:
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/refs/heads/main/monitoring/configs/dashboards/cluster.json
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -247,7 +247,7 @@ spec:
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/fluxcd/flux2-monitoring-example/refs/heads/main/monitoring/configs/dashboards/control-plane.json
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -262,7 +262,7 @@ spec:
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/controlplaneio-fluxcd/flux-operator/refs/heads/main/config/monitoring/dashboards/flux-k8s-api-performance.json
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -277,7 +277,7 @@ spec:
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/controlplaneio-fluxcd/flux-operator/refs/heads/main/config/monitoring/dashboards/flux-performance.json
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -292,7 +292,7 @@ spec:
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/kedacore/keda/main/config/grafana/keda-dashboard.json
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -307,7 +307,7 @@ spec:
       inputName: DS_PROMETHEUS
   url: https://raw.githubusercontent.com/cilium/cilium/main/install/kubernetes/cilium/files/cilium-agent/dashboards/cilium-dashboard.json
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -323,7 +323,7 @@ spec:
   # renovate: depName="Kubernetes / Views / Global"
   url: https://grafana.com/api/dashboards/15757/revisions/43/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -339,7 +339,7 @@ spec:
   # renovate: depName="Kubernetes / Views / Namespaces"
   url: https://grafana.com/api/dashboards/15758/revisions/46/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -355,7 +355,7 @@ spec:
   # renovate: depName="Kubernetes / Views / Nodes"
   url: https://grafana.com/api/dashboards/15759/revisions/40/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -371,7 +371,7 @@ spec:
   # renovate: depName="Kubernetes / Views / Pods"
   url: https://grafana.com/api/dashboards/15760/revisions/39/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -387,7 +387,7 @@ spec:
   # renovate: depName="etcd"
   url: https://grafana.com/api/dashboards/15055/revisions/7/download
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:

--- a/kubernetes/apps/observability/grafana/instance/grafanadatasource-loki.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadatasource-loki.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadatasource_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadatasource_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 metadata:

--- a/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadatasource_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadatasource_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 metadata:

--- a/kubernetes/apps/observability/grafana/instance/servicemonitor.yaml
+++ b/kubernetes/apps/observability/grafana/instance/servicemonitor.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/servicemonitor_v1.json
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/kubernetes/apps/observability/keda/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/keda/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/observability/keda/app/repository.yaml
+++ b/kubernetes/apps/observability/keda/app/repository.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/observability/keda/ks.yaml
+++ b/kubernetes/apps/observability/keda/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/observability/kube-state-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-state-metrics/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/observability/kube-state-metrics/app/repository.yaml
+++ b/kubernetes/apps/observability/kube-state-metrics/app/repository.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/observability/kube-state-metrics/ks.yaml
+++ b/kubernetes/apps/observability/kube-state-metrics/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/observability/node-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/node-exporter/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/observability/node-exporter/app/repository.yaml
+++ b/kubernetes/apps/observability/node-exporter/app/repository.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/observability/node-exporter/ks.yaml
+++ b/kubernetes/apps/observability/node-exporter/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/observability/prometheus-operator-crds/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/prometheus-operator-crds/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/observability/prometheus-operator-crds/app/repository.yaml
+++ b/kubernetes/apps/observability/prometheus-operator-crds/app/repository.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/observability/smartctl-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/grafanadashboard.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:

--- a/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/observability/smartctl-exporter/app/repository.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/repository.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/observability/smartctl-exporter/ks.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/observability/unpoller/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/unpoller/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/observability/unpoller/app/repository.yaml
+++ b/kubernetes/apps/observability/unpoller/app/repository.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/observability/unpoller/ks.yaml
+++ b/kubernetes/apps/observability/unpoller/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/rook-ceph/rook-ceph/app/repository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/repository.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/repository.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/repository.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/volsync-system/kopia/app/externalsecret.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/volsync-system/kopia/ks.yaml
+++ b/kubernetes/apps/volsync-system/kopia/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/volsync-system/volsync/app/dashboard.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/dashboard.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:

--- a/kubernetes/apps/volsync-system/volsync/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/volsync-system/volsync/app/prometheusrule.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/prometheusrule.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/operator.victoriametrics.com/vmrule_v1beta1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/operator.victoriametrics.com/vmrule_v1beta1.json
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:

--- a/kubernetes/apps/volsync-system/volsync/app/repository.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/repository.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/volsync-system/volsync/ks.yaml
+++ b/kubernetes/apps/volsync-system/volsync/ks.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -20,7 +20,7 @@ spec:
   interval: 30m
   timeout: 5m
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/volsync-system/volsync/maintenance/externalsecret.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
@@ -1,4 +1,7 @@
 ---
+# Only schema ref left on kubernetes-schemas.pages.dev: k8s-schemas.home-operations.com
+# publishes just replicationsource/replicationdestination for volsync.backube, so it has
+# no KopiaMaintenance schema to migrate to yet.
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/volsync.backube/kopiamaintenance_v1alpha1.json
 apiVersion: volsync.backube/v1alpha1
 kind: KopiaMaintenance

--- a/kubernetes/components/keda/nfs-scaler/scaledobject.yaml
+++ b/kubernetes/components/keda/nfs-scaler/scaledobject.yaml
@@ -1,5 +1,5 @@
 ---
-# yayamlls-disable-file
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/keda.sh/scaledobject_v1alpha1.json
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/kubernetes/components/keda/nfs-scaler/triggerauthentication.yaml
+++ b/kubernetes/components/keda/nfs-scaler/triggerauthentication.yaml
@@ -1,5 +1,5 @@
 ---
-# yayamlls-disable-file
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/keda.sh/clustertriggerauthentication_v1alpha1.json
 apiVersion: keda.sh/v1alpha1
 kind: ClusterTriggerAuthentication
 metadata:

--- a/kubernetes/components/volsync/externalsecret.yaml
+++ b/kubernetes/components/volsync/externalsecret.yaml
@@ -1,5 +1,6 @@
 ---
-# yayamlls-disable-file
+# No $schema: Flux postBuild substitutions land in typed fields here, so the
+# source is exempt in .yayamlls.yaml and validated rendered via --render.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/components/volsync/replicationdestination.yaml
+++ b/kubernetes/components/volsync/replicationdestination.yaml
@@ -1,5 +1,6 @@
 ---
-# yayamlls-disable-file
+# No $schema: Flux postBuild substitutions land in typed fields here, so the
+# source is exempt in .yayamlls.yaml and validated rendered via --render.
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
 metadata:

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -1,5 +1,6 @@
 ---
-# yayamlls-disable-file
+# No $schema: Flux postBuild substitutions land in typed fields here, so the
+# source is exempt in .yayamlls.yaml and validated rendered via --render.
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:


### PR DESCRIPTION
Closes #3830.

Validation-only change — no manifest semantics touched, zero cluster risk.

## Diagnosis first (issue's step one)

The issue asked to find out which problem each of the eight `# yayamlls-disable-file`
files actually has before changing anything. I pointed each one at a real schema and ran
`yayamlls validate`. The split is **5 / 3**:

| File | Kind | Cause | Fix |
|---|---|---|---|
| `components/keda/nfs-scaler/scaledobject.yaml` | keda ScaledObject | missing schema | real schema ✅ |
| `components/keda/nfs-scaler/triggerauthentication.yaml` | keda ClusterTriggerAuthentication | missing schema | real schema ✅ |
| `apps/default/minecraft/app/scaledobject.yaml` | keda ScaledObject | missing schema | real schema ✅ |
| `apps/default/minecraft/app/repository.yaml` | Flux OCIRepository | missing schema | real schema ✅ |
| `apps/default/minecraft/app/mc-router-repository.yaml` | Flux OCIRepository | missing schema | real schema ✅ |
| `components/volsync/replicationsource.yaml` | ReplicationSource | **postBuild substitution** | documented source-only exemption |
| `components/volsync/replicationdestination.yaml` | ReplicationDestination | **postBuild substitution** | documented source-only exemption |
| `components/volsync/externalsecret.yaml` | ExternalSecret | **postBuild substitution** | documented source-only exemption |

The caveat in the issue was correct. The three volsync component sources put Flux
variables in typed fields and a *correct* schema rejects them pre-substitution:

```
replicationsource.yaml: got string, want null or integer (at /spec/kopia/moverSecurityContext/runAsUser)
replicationsource.yaml: '${VOLSYNC_CAPACITY:=5Gi}' does not match pattern '^(\+|-)?(([0-9]+...'  (at /spec/kopia/cacheCapacity)
externalsecret.yaml:    '${APP}-volsync-secret' does not match pattern '^[a-z0-9]([-a-z0-9]*...' (at /spec/target/name)
```

**`yayamlls validate --render` does cover them** — verified: it validates
`ReplicationSource/docmost`, `ReplicationDestination/plex-dst` and the rest with
substitutions applied, and the type errors above do not appear there. So the exemption is
narrowed to source-only, the redundant second disable mechanism (`# yayamlls-disable-file`
*and* a `.yayamlls.yaml` entry on the same files) is gone, and `.yayamlls.yaml` now records
*why* each remaining entry is there.

## Host consolidation

`yayamlls`' own built-in CRD catalog **already resolves from
`k8s-schemas.home-operations.com`** (confirmed in the 0.1.11 binary). The inline `$schema`
comments were overriding the tool's correct default with a less-maintained mirror.

| Host | Before | After |
|---|---:|---:|
| `k8s-schemas.home-operations.com` | 0 | **108** |
| `json.schemastore.org` | 57 | 60 |
| `raw.githubusercontent.com` | 58 | 51 |
| `kubernetes-schemas.pages.dev` | 86 | 1 |
| `kochhaus-schemas.pages.dev` | 4 | 0 |
| `datreeio.github.io` | 3 | 0 |
| `crd.movishell.pl` | 3 | 0 |
| `github.com` (datreeio raw form) | 3 | 0 |
| `lds-schemas.pages.dev` | 1 | 0 |

**8 hosts → 4.** Every path was verified to return `200` on the new host *before* the
swap — the layout is identical, so the bulk edit was safe. All 30 schema URLs in the repo
now resolve (`200`, plus the usual `301` on `json.schemastore.org/kustomization`).

## Pre-existing errors the stricter validation surfaced

As the issue predicted — all fixed here:

- **Seven ExternalSecrets** declare `external-secrets.io/v1` but referenced the
  **`externalsecret_v1beta1`** schema. Now on `externalsecret_v1.json`.
- **`raw.githubusercontent.com/axeII/crds`** (a personal mirror, counted under
  raw.githubusercontent in the issue's table) served the **wrong kinds**: a `v2beta1`
  HelmRelease schema on a `v2` HelmRelease, and a *Flux* Kustomization schema on two
  `kustomize.config.k8s.io` `kustomization.yaml` files. Repointed at the Flux v2 schema and
  `json.schemastore.org/kustomization`, matching the 30 other `kustomization.yaml` files.
- **`token.sops.yaml`** was absent from the exemption list, so the SchemaStore catalog
  matched it on filename to an unrelated 1Password schema and failed to load it on *every*
  `just validate` run. The four sops globs collapse to one `**/*.sops.yaml`, which fixes it
  and is future-proof.
- **`dragonfly/cluster/cluster.yaml`** was exempted because the catalog matched
  `cluster.yaml` to an unrelated schema. It now has a real `Dragonfly` schema instead of
  an exemption — strictly more validation.

## Decisions and open items

- **`.yayamlls-schemas/any.json` is kept.** It still has legitimate consumers: the
  SOPS-encrypted documents (ciphertext payload, `sops` block in no upstream schema) and the
  three substitution-bound volsync sources. The issue's deletion bullet was conditional on
  having none left.
- **Left on `raw.githubusercontent.com`:** `fluxcd-community/flux2-schemas` (35),
  `bjw-s`/`bjw-s-labs` app-template HelmRelease (13), `yannh/kubernetes-json-schema` (2),
  `recyclarr` (1). These are maintained org repos, not personal `pages.dev`, and the
  app-template one is an *enriched* HelmRelease schema that k8s-schemas does not replace.
  Possible follow-up: normalize the 6 `bjw-s/helm-charts` URLs to `bjw-s-labs` (they work
  today only via GitHub's rename redirect).
- **`json.schemastore.org` left alone**, per the issue.
- **KopiaMaintenance is the one holdout** on `kubernetes-schemas.pages.dev`: k8s-schemas
  publishes only `replicationsource` and `replicationdestination` for `volsync.backube`. A
  comment in the file records why, so nobody "fixes" it into a 404. Worth an upstream
  request to `home-operations/k8s-schemas`.
- **`--render` is not wired into `just validate`.** It currently reports
  `additional properties 'kopia' not allowed` on every rendered volsync
  ReplicationSource/Destination, because the k8s-schemas volsync schema is stale — it
  predates the kopia mover (`spec` keys: `external paused rclone restic rsync rsyncTLS
  sourcePVC syncthing trigger`, no `kopia`; bjw-s's older mirror does have it). Adopting
  `--render` in CI needs that upstream refresh first, plus the 4 unrelated flate
  "not found" renders and a paperless `supplementalGroups` finding. Out of scope here.
- **OCI artifact** (`ghcr.io/home-operations/k8s-schemas:latest`) not adopted — CI is not
  flaking on network, and the issue marked it optional.

## Validation

```
pre-commit run --all-files      all 11 hooks Passed
just configure                  exit 0
just validate                   exit 0, no output  (was printing a schema-load failure before)
just flate-test                 ✓ 169 passed, 1 pre-existing warning (external-dns-cloudflare values)
find_mistakes.py                2 pre-existing warnings (affine unregistered, rook-ceph common component)
```

`just validate` is now silent *and* validating strictly more than before: five files gained
real schemas, dragonfly swapped an exemption for a real schema, and seven ExternalSecrets
are checked against the API version they actually declare.

## Note for the reviewer

An unrelated uncommitted edit to `scripts/find_mistakes.py` (registering
`check_client_tool_versions` in the checks list) was already in the working tree and is
**deliberately left out** of this PR — it is a separate concern.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)