### PR TITLE
chore(postgres-init): unify remaining apps on ghcr.io/home-operations image

### DIFF
--- a/kubernetes/apps/default/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/atuin/app/helmrelease.yaml
@@ -25,8 +25,8 @@ spec:
         initContainers:
           init-db:
             image:
-              repository: ghcr.io/onedr0p/postgres-init
-              tag: 16
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 17.6
             envFrom: &envFrom
               - secretRef:
                   name: atuin-secret

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -24,8 +24,8 @@ spec:
         initContainers:
           init-db:
             image:
-              repository: ghcr.io/onedr0p/postgres-init
-              tag: 16
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 17.6
             envFrom: &envFrom
               - secretRef:
                   name: prowlarr-secret

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -25,8 +25,8 @@ spec:
         initContainers:
           init-db:
             image:
-              repository: ghcr.io/onedr0p/postgres-init
-              tag: 16
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 17.6
             envFrom: &envFrom
               - secretRef:
                   name: radarr-secret

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -25,8 +25,8 @@ spec:
         initContainers:
           init-db:
             image:
-              repository: ghcr.io/onedr0p/postgres-init
-              tag: 16
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 17.6
             envFrom: &envFrom
               - secretRef:
                   name: sonarr-secret

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -25,8 +25,8 @@ spec:
         initContainers:
           init-db:
             image:
-              repository: ghcr.io/onedr0p/postgres-init
-              tag: 16
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 17.6
             envFrom: &envFrom
               - secretRef:
                   name: gatus-secret


### PR DESCRIPTION
Part 1 of #3828 — the lowest-risk of the three realignments. Parts 2 (external-dns-unifi-webhook) and 3 (snapshot-controller) follow as separate PRs.

## What changed

Five HelmReleases still pulled the pre-transfer `ghcr.io/onedr0p/postgres-init:16` image. The image now lives in `home-operations/containers`; the stale half was also a client major behind.

| App | File |
|---|---|
| atuin | `kubernetes/apps/default/atuin/app/helmrelease.yaml` |
| gatus | `kubernetes/apps/observability/gatus/app/helmrelease.yaml` |
| prowlarr | `kubernetes/apps/media/prowlarr/app/helmrelease.yaml` |
| radarr | `kubernetes/apps/media/radarr/app/helmrelease.yaml` |
| sonarr | `kubernetes/apps/media/sonarr/app/helmrelease.yaml` |

All five now read `ghcr.io/home-operations/postgres-init` / `17.6`, matching the block style already used by `paperless`, `docmost`, `affine` and `seerr` (which were already on `17.6`). No other keys touched.

## Why

Single canonical upstream for the image, and one `postgres-init` version across the repo instead of a 16/17.6 split.

## Validation

Full chain run on the branch, all green:

- `just configure` — clean
- `just validate` (yayamlls) — clean
- `just flate-test` — 169 passed; the one warning (`external-dns-cloudflare: values not used by the chart`) is pre-existing and unrelated
- `python3 scripts/find_mistakes.py` — exits 0; the two warnings (unregistered `affine`, missing common component in `rook-ceph`) are the known clean-tree ones
- `pre-commit run --all-files` — all hooks passed

## Cautions for review

- **Confirm the postgres server version before merging.** The tag is the libpq *client* major, not the server; the server is external (`db.internal`) and its version is not readable from this repo. A 17.x client against a 16.x server is supported (libpq is backward compatible), so this is expected to be a no-op — but worth a glance, as the issue notes.
- Init containers only. Worst case is a pod stuck in `Init:` and a one-line revert.
- Watch the five init containers complete after Flux reconciles.
- Not addressed here: `.renovate/allowedVersions.json5` pins `/postgresql/` to `<=17`, which does **not** match `postgres-init`, so this image stays unconstrained by Renovate. The issue raises it as a "consider" — left for a separate decision rather than bundled in.

Konflate blast radius was not queried — it is reachable only from inside the home network.
