### PR TITLE
feat(external-dns-unifi): move to the home-operations webhook and API-key auth

### DIFF
--- a/kubernetes/apps/network/external-dns/unifi/externalsecret.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/externalsecret.yaml
@@ -14,8 +14,7 @@ spec:
     template:
       engineVersion: v2
       data:
-        UNIFI_USER: "{{ .EXTERNAL_DNS_UNIFI_USER }}"
-        UNIFI_PASS: "{{ .EXTERNAL_DNS_UNIFI_PASS }}"
+        UNIFI_API_KEY: "{{ .EXTERNAL_DNS_UNIFI_API_KEY }}"
   dataFrom:
     - extract:
         key: unifi

--- a/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
@@ -29,20 +29,15 @@ spec:
       name: webhook
       webhook:
         image:
-          repository: ghcr.io/kashalls/external-dns-unifi-webhook
-          tag: v0.9.0@sha256:22f4106f44a0b9ac3c97cf29bbfef93026c1164492152dc797a1d6dc86ddfbb5
+          repository: ghcr.io/home-operations/external-dns-unifi-webhook
+          tag: 0.10.12@sha256:5338b99662e2e15048b4e14b49e17279d384970fdcb3c29169f509f806f49cbe
         env:
           - name: UNIFI_HOST
             value: https://unifi.internal
-          - name: &name UNIFI_USER
+          - name: &name UNIFI_API_KEY
             valueFrom:
               secretKeyRef:
                 name: &secret external-dns-unifi-secret
-                key: *name
-          - name: &name UNIFI_PASS
-            valueFrom:
-              secretKeyRef:
-                name: *secret
                 key: *name
         livenessProbe:
           httpGet:
@@ -56,7 +51,9 @@ spec:
             port: http-webhook
           initialDelaySeconds: 10
           timeoutSeconds: 5
-    policy: sync
+    # TODO: restore `sync` once the 0.10.x Integration API provider is confirmed
+    # to be reconciling records correctly; upsert-only cannot prune.
+    policy: upsert-only
     sources: ["crd", "gateway-httproute", "service"]
     txtOwnerId: k8s
     txtPrefix: k8s.


### PR DESCRIPTION
Part 2 of #3828. Highest-risk of the three — a bad rollout means DNS records stop reconciling.

## What changed

`kubernetes/apps/network/external-dns/unifi/helmrelease.yaml`
- Image: `ghcr.io/kashalls/external-dns-unifi-webhook:v0.9.0` → `ghcr.io/home-operations/external-dns-unifi-webhook:0.10.12` (+ digest).
- The two `UNIFI_USER` / `UNIFI_PASS` env entries collapse into a single `UNIFI_API_KEY` `secretKeyRef`. `UNIFI_HOST`, the probes and the reloader annotation are untouched.
- `policy: sync` → `policy: upsert-only`, with a TODO to restore it. See below.

`kubernetes/apps/network/external-dns/unifi/externalsecret.yaml`
- Template keys `UNIFI_USER` / `UNIFI_PASS` → `UNIFI_API_KEY: "{{ .EXTERNAL_DNS_UNIFI_API_KEY }}"`, still extracted from the `unifi` item.

## Why this is not a version bump

The project transferred to `home-operations` (same repo; `kashalls/...` is now a redirect). The tag scheme changed at the transfer — `v0.9.0` → `0.10.0`, dropping the `v` — so the version stream looked discontinuous and Renovate never proposed the update. We were 12 releases behind.

**0.10.x removes username/password auth entirely.** It is API-key only, and talks to the UniFi Network *Integration API* (`/proxy/network/integration/v1`, DNS Policies) instead of the legacy endpoints.

## Prerequisites — confirmed before writing this

- UniFi Network >= 10.3.58 (Integration API DNS Policy endpoints) — confirmed by the maintainer.
- `EXTERNAL_DNS_UNIFI_API_KEY` present in the `unifi` 1Password item — confirmed by the maintainer.
- ExternalDNS >= v0.21.0 — verified from the render: chart `1.21.1` produces `registry.k8s.io/external-dns/external-dns:v0.21.0`.

## Deviations from the issue

- **Tag `0.10.12`, not `0.10.11`.** `0.10.12` is the latest published tag; same 0.10.x auth model, so it changes nothing about the migration.
- **`policy: upsert-only`.** The issue raised this as a "consider"; taking it, since `sync` plus a misconfigured provider is exactly how records get pruned. Restoring `sync` is a one-line follow-up PR once records are confirmed intact — the TODO in the file says so.

## Verification

Rendered with `flate build hr external-dns-unifi`:

```
- --policy=upsert-only
image: registry.k8s.io/external-dns/external-dns:v0.21.0
- name: UNIFI_HOST
  value: https://unifi.internal
- name: UNIFI_API_KEY
  valueFrom:
    secretKeyRef:
      key: UNIFI_API_KEY
      name: external-dns-unifi-secret
image: ghcr.io/home-operations/external-dns-unifi-webhook:0.10.12@sha256:5338b99662e2e15048b4e14b49e17279d384970fdcb3c29169f509f806f49cbe
```

No `UNIFI_USER` / `UNIFI_PASS` remain in the rendered output.

Full chain, all green:
- `just configure` — clean
- `just validate` (yayamlls) — clean
- `just flate-test` — 169 passed; the one warning (`external-dns-cloudflare: values not used by the chart`) is pre-existing and unrelated
- `python3 scripts/find_mistakes.py` — exits 0, only the two known clean-tree warnings
- `pre-commit run --all-files` — all hooks passed

## Post-merge checks

1. Webhook container comes up without auth errors — it now hits `/proxy/network/integration/v1`, so a 401 means the key lacks Site Admin on the right site.
2. `kubectl logs` the external-dns container and confirm records reconcile.
3. Confirm existing DNS records in UniFi are intact.
4. Restore `policy: sync` in a follow-up PR.
5. Confirm Renovate picks up the new `0.10.x` stream — the `v`-prefix discontinuity should resolve now that we're on the new scheme.
6. Remove `EXTERNAL_DNS_UNIFI_USER` / `EXTERNAL_DNS_UNIFI_PASS` from 1Password only **after** this is confirmed working.

## Cautions

- Wildcards and multi-target CNAMEs remain unsupported (dnsmasq backend) — unchanged from 0.9.0, but worth knowing.
- If the API key was created while the user was Super Admin and then downgraded to Site Admin, the key keeps working — but verify it covers the site serving `${SECRET_DOMAIN}`.

Konflate blast radius was not queried — it is reachable only from inside the home network.
