### PR TITLE
ci(flate): fail PRs that would delete CRDs on Helm upgrade

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -28,6 +28,8 @@
 # Excluded by auto-merge and bulk-merge-prs; label-sync prunes anything not listed
 # here, so it has to be declared to survive.
 - { name: "hold", color: "ee0701" }
+# Applied by hand to tell the Flate CRD guard a deletion was reviewed and is intended.
+- { name: "crd-deletion-ack", color: "fbca04" }
 # General
 - { name: "bug", color: "a4ffae" }
 - { name: "deploy", color: "1f6feb" }

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -25,6 +25,9 @@
 - { name: "type/digest", color: "ffeC19" }
 # Uncategorized
 - { name: "do not merge", color: "ee0701" }
+# Excluded by auto-merge and bulk-merge-prs; label-sync prunes anything not listed
+# here, so it has to be declared to survive.
+- { name: "hold", color: "ee0701" }
 # General
 - { name: "bug", color: "a4ffae" }
 - { name: "deploy", color: "1f6feb" }

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -51,3 +51,111 @@ jobs:
 
       - name: Run flate test
         run: flate test all --path kubernetes/flux
+
+  # Helm deletes any resource that was in the previous release manifest and is absent
+  # from the new one. A chart that moves its CRDs from templates/ (rendered into the
+  # manifest) to crds/ (excluded by Helm) therefore deletes them on upgrade — along
+  # with every custom resource they own. flate models this correctly, but --skip-crds
+  # defaults to true, so the removal never reaches the rendered diff and neither
+  # `flate test` nor konflate can see it. This job renders CRDs on both sides and
+  # fails when one disappears. It is silent on every PR that does not do this.
+  crd-guard:
+    if: ${{ needs.filter.outputs.changed-files != '[]' }}
+    needs: filter
+    name: Flate - CRD Guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # The base tree is rendered too, so its history must be present.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          # Only this job's tool — mise.toml also pins the workstation set.
+          install_args: "github:home-operations/flate"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Compare rendered CRD sets
+        id: crds
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          render_crds() {
+            flate build hr --path kubernetes/flux --only-crds -o json --no-progress \
+              | jq -r '.[].metadata.name' | sort -u
+          }
+
+          render_crds > /tmp/head-crds.txt
+
+          # flate resolves the Flux GitRepository against a real repo, so the baseline
+          # tree needs to be one — git archive alone leaves a bare directory.
+          base_dir="$(mktemp -d)"
+          git archive "origin/${BASE_REF}" | tar -x -C "${base_dir}"
+          git -C "${base_dir}" init -q .
+          git -C "${base_dir}" add -A
+          git -C "${base_dir}" -c user.email=ci@local -c user.name=ci commit -qm baseline
+          (cd "${base_dir}" && render_crds) > /tmp/base-crds.txt
+
+          echo "baseline CRDs: $(wc -l < /tmp/base-crds.txt), this PR: $(wc -l < /tmp/head-crds.txt)"
+
+          removed="$(comm -23 /tmp/base-crds.txt /tmp/head-crds.txt || true)"
+          # A count, not the list: an empty multiline output can serialise as a bare
+          # newline rather than "", which would trip the guard on every PR.
+          count="$(printf '%s' "${removed}" | grep -c . || true)"
+          echo "count=${count}" >> "${GITHUB_OUTPUT}"
+
+          if [ "${count}" -eq 0 ]; then
+            echo "No CRD leaves the rendered output." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          {
+            echo "## :rotating_light: This upgrade would delete CRDs"
+            echo
+            echo "These CRDs render from the base branch but not from this PR, so Helm"
+            echo "will delete them on upgrade — **and every custom resource they own**:"
+            echo
+            echo '```'
+            echo "${removed}"
+            echo '```'
+            echo
+            echo "The PR has been labelled \`hold\` to keep auto-merge away from it."
+            echo
+            echo "### If this is a deliberate \`templates/\` to \`crds/\` migration"
+            echo
+            echo "1. Annotate the live CRDs so Helm skips the delete:"
+            echo "   \`kubectl annotate crd <name> helm.sh/resource-policy=keep --overwrite\`"
+            echo "2. Verify every one of them reports \`keep\` before merging."
+            echo "3. Set \`upgrade.crds: Skip\` on the HelmRelease for the transition."
+            echo "   \`CreateReplace\` does **not** protect them: Flux force-replaces the live"
+            echo "   CRDs before the upgrade runs, which strips the annotation Helm is about"
+            echo "   to check. Restore \`CreateReplace\` in a follow-up once the CRDs are"
+            echo "   orphaned from the release manifest."
+            echo
+            echo "Inspect the full picture with \`flate diff hr --skip-crds=false\`."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          echo "::error::${removed//$'\n'/ }"
+
+      - name: Hold the PR
+        if: ${{ steps.crds.outputs.count != '0' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.number }}" --add-label hold \
+            || echo "::warning::could not apply the 'hold' label — a fork PR's token is read-only"
+
+      - name: Fail when CRDs would be deleted
+        if: ${{ steps.crds.outputs.count != '0' }}
+        run: exit 1

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -57,8 +57,10 @@ jobs:
   # manifest) to crds/ (excluded by Helm) therefore deletes them on upgrade — along
   # with every custom resource they own. flate models this correctly, but --skip-crds
   # defaults to true, so the removal never reaches the rendered diff and neither
-  # `flate test` nor konflate can see it. This job renders CRDs on both sides and
-  # fails when one disappears. It is silent on every PR that does not do this.
+  # `flate test` nor konflate can see it. This job renders CRDs on both sides and,
+  # when one disappears, comments on the PR, labels it hold and fails. A reviewer who
+  # has checked the deletion is intended adds crd-deletion-ack and re-runs the job,
+  # which drops the hold and passes. Silent on every PR that removes no CRD.
   crd-guard:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
     needs: filter
@@ -83,11 +85,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Compare rendered CRD sets
-        id: crds
+      - name: Guard against CRD deletion
         shell: bash
         env:
           BASE_REF: ${{ github.base_ref }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.number }}
+          GH_TOKEN: ${{ github.token }}
+          HOLD_LABEL: hold
+          ACK_LABEL: crd-deletion-ack
+          MARKER: "<!-- flate-crd-guard -->"
         run: |
           set -euo pipefail
 
@@ -113,49 +120,92 @@ jobs:
           # A count, not the list: an empty multiline output can serialise as a bare
           # newline rather than "", which would trip the guard on every PR.
           count="$(printf '%s' "${removed}" | grep -c . || true)"
-          echo "count=${count}" >> "${GITHUB_OUTPUT}"
 
           if [ "${count}" -eq 0 ]; then
             echo "No CRD leaves the rendered output." >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi
 
-          {
-            echo "## :rotating_light: This upgrade would delete CRDs"
-            echo
-            echo "These CRDs render from the base branch but not from this PR, so Helm"
-            echo "will delete them on upgrade — **and every custom resource they own**:"
-            echo
-            echo '```'
-            echo "${removed}"
-            echo '```'
-            echo
-            echo "The PR has been labelled \`hold\` to keep auto-merge away from it."
-            echo
-            echo "### If this is a deliberate \`templates/\` to \`crds/\` migration"
-            echo
-            echo "1. Annotate the live CRDs so Helm skips the delete:"
-            echo "   \`kubectl annotate crd <name> helm.sh/resource-policy=keep --overwrite\`"
-            echo "2. Verify every one of them reports \`keep\` before merging."
-            echo "3. Set \`upgrade.crds: Skip\` on the HelmRelease for the transition."
-            echo "   \`CreateReplace\` does **not** protect them: Flux force-replaces the live"
-            echo "   CRDs before the upgrade runs, which strips the annotation Helm is about"
-            echo "   to check. Restore \`CreateReplace\` in a follow-up once the CRDs are"
-            echo "   orphaned from the release manifest."
-            echo
-            echo "Inspect the full picture with \`flate diff hr --skip-crds=false\`."
-          } >> "${GITHUB_STEP_SUMMARY}"
+          # Read labels live. "Re-run failed jobs" replays the original event payload,
+          # so github.event.pull_request.labels would still show the pre-ack set.
+          acked=false
+          if gh pr view "${PR}" --repo "${REPO}" --json labels --jq '.labels[].name' \
+              | grep -qx "${ACK_LABEL}"; then
+            acked=true
+          fi
 
-          echo "::error::${removed//$'\n'/ }"
+          if [ "${acked}" = true ]; then
+            {
+              echo "${MARKER}"
+              echo "### :white_check_mark: CRD deletion acknowledged"
+              echo
+              echo "Approved via the \`${ACK_LABEL}\` label. Merging this deletes the following"
+              echo "CRDs and every custom resource they own:"
+              echo
+              echo '```'
+              echo "${removed}"
+              echo '```'
+              echo
+              echo "\`${HOLD_LABEL}\` has been removed. If these CRDs must survive, confirm the live"
+              echo "objects carry \`helm.sh/resource-policy: keep\` before merging."
+            } > /tmp/crd-comment.md
+          else
+            {
+              echo "${MARKER}"
+              echo "### :rotating_light: This PR would delete CRDs"
+              echo
+              echo "Helm deletes whatever was in the previous release manifest and is absent from"
+              echo "the new one. These CRDs render from \`${BASE_REF}\` but not from this PR, so the"
+              echo "upgrade deletes them — **and every custom resource they own**:"
+              echo
+              echo '```'
+              echo "${removed}"
+              echo '```'
+              echo
+              echo "Labelled \`${HOLD_LABEL}\`, so auto-merge will skip it."
+              echo
+              echo "**If this is not intended**, the chart has most likely moved its CRDs from"
+              echo "\`templates/\` to \`crds/\`, which Helm excludes from the release manifest. Before"
+              echo "merging:"
+              echo
+              echo "1. Annotate the live CRDs so Helm skips the delete:"
+              echo "   \`kubectl annotate crd <name> helm.sh/resource-policy=keep --overwrite\`"
+              echo "2. Verify every one of them reports \`keep\`."
+              echo "3. Set \`upgrade.crds: Skip\` on the HelmRelease for the transition."
+              echo "   \`CreateReplace\` does **not** protect them: Flux force-replaces the live CRDs"
+              echo "   before the upgrade runs, stripping the annotation Helm is about to check."
+              echo
+              echo "**If this is intended and reviewed**, add the \`${ACK_LABEL}\` label and re-run"
+              echo "this job (*Re-run failed jobs*). That records the decision, drops \`${HOLD_LABEL}\`,"
+              echo "and turns this check green."
+              echo
+              echo "<sub>Inspect with \`flate diff hr --skip-crds=false\`.</sub>"
+            } > /tmp/crd-comment.md
+          fi
 
-      - name: Hold the PR
-        if: ${{ steps.crds.outputs.count != '0' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh pr edit "${{ github.event.number }}" --add-label hold \
-            || echo "::warning::could not apply the 'hold' label — a fork PR's token is read-only"
+          cat /tmp/crd-comment.md >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Fail when CRDs would be deleted
-        if: ${{ steps.crds.outputs.count != '0' }}
-        run: exit 1
+          # Upsert one comment rather than adding a new one on every push.
+          existing="$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+            --jq '.[] | select(.body | contains("flate-crd-guard")) | .id' 2>/dev/null | head -1 || true)"
+          if [ -n "${existing}" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${existing}" \
+              -F body=@/tmp/crd-comment.md >/dev/null \
+              || echo "::warning::could not update the guard comment"
+          else
+            gh api -X POST "repos/${REPO}/issues/${PR}/comments" \
+              -F body=@/tmp/crd-comment.md >/dev/null \
+              || echo "::warning::could not post the guard comment"
+          fi
+
+          if [ "${acked}" = true ]; then
+            gh pr edit "${PR}" --repo "${REPO}" --remove-label "${HOLD_LABEL}" >/dev/null 2>&1 || true
+            echo "Acknowledged via ${ACK_LABEL} — ${count} CRD(s) approved for deletion."
+            exit 0
+          fi
+
+          gh pr edit "${PR}" --repo "${REPO}" --add-label "${HOLD_LABEL}" >/dev/null \
+            || echo "::warning::could not apply '${HOLD_LABEL}' — a fork PR's token is read-only"
+
+          echo "::error::${count} CRD(s) would be deleted: ${removed//$'\n'/ }"
+          exit 1


### PR DESCRIPTION
Closes a hole found while reviewing #3917: a chart upgrade can delete CRDs — and every custom resource they own — with the entire validation chain green.

## The hole

`helm upgrade` deletes anything present in the previous release manifest and absent from the new one. A chart that moves its CRDs from `templates/` (rendered into the release manifest) to `crds/` (excluded by Helm) therefore **deletes them on upgrade**, cascading to every CR they own.

Nothing in CI surfaces this today. Not because flate models it wrong — it models it exactly right — but because **`--skip-crds` defaults to `true`**, so the removals are filtered out of the rendered output before anything compares them. `flate test` passes, and konflate's blast radius shows only the unrelated churn.

In #3917 that meant six snapshot CRDs, 12 VolumeSnapshots and 12 VolumeSnapshotContents (~68 GiB of Ceph RBD snapshots, all `deletionPolicy: Delete`) were queued for deletion behind a fully green PR.

This matters most for the PRs nobody reads closely: a Renovate `type/patch` or `type/minor` chart bump that happens to relocate CRDs is auto-merged after 2–3 days on label and age rules alone.

## The check

New `crd-guard` job in the existing Flate workflow. Renders CRDs from both the base branch and the PR, and compares the name sets:

```bash
flate build hr --path kubernetes/flux --only-crds -o json \
  | jq -r '.[].metadata.name' | sort -u
comm -23 base-crds.txt head-crds.txt     # non-empty = Helm will delete these
```

A CRD that renders from the base and not from the PR is, by definition, one Helm will delete. That is the entire heuristic — no file-path matching, no chart allow-list. It fires on the condition itself, so it stays silent on every PR that does not do this, and it generalises to any chart that stops shipping a CRD rather than just `templates/` → `crds/`.

## What happens when it trips

| Condition | Result |
|---|---|
| No CRD removed | Silent pass |
| CRD removed, not acknowledged | Comments on the PR naming the CRDs, applies `hold`, fails |
| CRD removed, `crd-deletion-ack` applied | Removes `hold`, rewrites the comment to record what was approved, passes |

The comment carries the remediation inline (annotate `helm.sh/resource-policy=keep`, verify, set `upgrade.crds: Skip`) so the reviewer does not have to go digging. It is upserted against a hidden marker, so repeated pushes update one comment instead of stacking new ones.

`crd-deletion-ack` is the deliberate escape hatch: apply it, hit *Re-run failed jobs*, and the check goes green. One auditable action that records a human reviewed the deletion — as opposed to the alternative, which was "delete a label and ignore the red check" and leaves no trace.

**Labels are read live through the API, not from `github.event.pull_request.labels`.** Re-running a job replays the original event payload, so the event's label list would never contain the label you just added and the escape hatch would silently never work.

## Why `hold` rather than relying on a red check

`auto-merge.yaml` treats merge state `UNSTABLE` as mergeable — that is precisely "a non-required check is failing". And the `main` ruleset (active) enforces only `pull_request` and `non_fast_forward`: **no required status checks, zero required approvals**. So a red check alone blocks nothing.

`hold` is honoured by both `auto-merge.yaml` and `bulk-merge-prs.yaml`, needs no repo-settings change, and is not managed by `pr-classify` — unlike `needs-review`, which `pr-classify` actively removes on its hourly run and would strip straight back off a patch PR.

Worth considering separately: adding `Flate - CRD Guard` to the ruleset as a required status check. That would make `crd-deletion-ack` the *only* path through rather than one of two. It is a repo-settings change, not something this PR can carry.

## Drive-by fix: `hold` was never a real label

`label-sync` runs with `delete-other-labels: true` against `.github/labels.yaml`, and `hold` is not in that file. Every `hold` exclusion in `auto-merge.yaml` and `bulk-merge-prs.yaml` has therefore been matching a label the sync deletes. Declared it, along with `crd-deletion-ack`, so those exclusions — and this guard — actually work.

## Verified end to end

**Locally**, running the real script against real flate and git with only `gh` stubbed, all three branches behave: unacknowledged (comment + `hold` + exit 1), acknowledged (comment + remove `hold` + exit 0), and the upsert path (PATCH rather than POST when a comment already exists).

**In CI**, on a throwaway PR (#3923, since closed and its branch deleted) carrying this guard plus one commit dropping `prometheus-operator-crds` from the observability kustomization:

1. `Flate - CRD Guard` **failed**, posted exactly one comment naming all 10 `monitoring.coreos.com` CRDs, and applied `hold`.
2. Adding `crd-deletion-ack` and re-running: check **passed**, `hold` removed, still exactly one comment, body switched to the acknowledgement text.

That second step is the real test of the live-label read — the re-run replayed an event payload that predates the label, and the guard saw it anyway.

Against #3917's branch the guard reports `baseline CRDs: 113, this PR: 107` and names exactly the six snapshot CRDs — Helm's delete set, nothing else.

False-positive check: `origin/main` rendered twice into separate trees produced identical output, so the comparison is deterministic and will not flap. This PR is its own negative test — it touches no manifests, so both sides render 113 CRDs and the guard passes silently.

`pre-commit run --all-files` passes; the embedded script passes `bash -n`. No `actionlint` is pinned in `mise.toml`, so workflow syntax otherwise leans on megalinter.

## Notes and limits

- **It compares base-render against PR-render; Helm compares the *stored release manifest* against the PR-render.** Those coincide when the live release matches main, which is the normal GitOps case, but they diverge under drift. Catching that needs cluster access — konflate is the only component positioned to do it, and doing so would catch every silent deletion, not just CRDs. Worth raising upstream.
- The base tree is rendered too, so the job checks out with `fetch-depth: 0` and materialises the base into a tempdir. flate resolves the Flux `GitRepository` against a real repo, so that tempdir gets a throwaway `git init` — `git archive` alone leaves a plain directory and the render fails.
- Cheap in practice: both renders completed in ~10s on #3922's first run, since flate's chart cache is user-level and shared between them.
- On a fork PR the `pull_request` token is read-only, so commenting and labelling are best-effort and only warn. The check still fails. Not a concern for Renovate, which pushes branches to this repo.
- `hold` and `crd-deletion-ack` were created directly on the repo to run the verification above. Until this merges they are not in main's `labels.yaml`, so a `label-sync` run triggered by some other PR would prune them; merging this restores them permanently.
